### PR TITLE
Modules with status error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM bringauto/cpp-build-environment:latest AS cpp_builder
 
-ARG MISSION_MODULE_VERSION=v1.2.5
-ARG IO_MODULE_VERSION=v1.2.5
+ARG MISSION_MODULE_VERSION=v1.2.6
+ARG IO_MODULE_VERSION=v1.2.6
 
 RUN mkdir /home/bringauto/modules
 ARG CMLIB_REQUIRED_ENV_TMP_PATH=/home/bringauto/modules/cmlib_cache


### PR DESCRIPTION
Updated modules with versions that contain changes needed to send STATUS_ERROR type messages to Fleet Protocol API

Depends on:
https://github.com/bringauto/io-module/pull/12
https://github.com/bringauto/fleet-protocol-http-api/pull/11