### PR TITLE
Fixed protobuf imports

### DIFF
--- a/external_server/command_waiting_thread.py
+++ b/external_server/command_waiting_thread.py
@@ -1,9 +1,6 @@
 import threading
 from queue import Queue, Empty
 import logging
-import sys
-
-sys.path.append("lib/fleet-protocol/protobuf/compiled/python")
 
 import InternalProtocol_pb2 as internal_protocol
 from external_server.structures import GeneralErrorCodes, EsErrorCodes

--- a/external_server/external_server.py
+++ b/external_server/external_server.py
@@ -1,8 +1,5 @@
 import logging
 import time
-import sys
-
-sys.path.append("lib/fleet-protocol/protobuf/compiled/python")
 
 import ExternalProtocol_pb2 as external_protocol
 import InternalProtocol_pb2 as internal_protocol

--- a/external_server/external_server_api_client.py
+++ b/external_server/external_server_api_client.py
@@ -1,10 +1,6 @@
 import ctypes as ct
 import threading
-import sys
 
-sys.path.append("lib/fleet-protocol/protobuf/compiled/python")
-
-import ExternalProtocol_pb2 as external_protocol
 import InternalProtocol_pb2 as internal_protocol
 from external_server.utils import check_file_exists
 from external_server.structures import (

--- a/external_server/message_creator.py
+++ b/external_server/message_creator.py
@@ -1,9 +1,3 @@
-import sys
-
-from external_server.structures import Buffer
-
-sys.path.append("lib/fleet-protocol/protobuf/compiled/python")
-
 import ExternalProtocol_pb2 as external_protocol
 import InternalProtocol_pb2 as internal_protocol
 

--- a/external_server/utils.py
+++ b/external_server/utils.py
@@ -1,9 +1,6 @@
 import argparse
 import os.path
-import sys
 import threading
-
-sys.path.append("lib/fleet-protocol/protobuf/compiled/python")
 
 import InternalProtocol_pb2 as internal_protocol
 

--- a/external_server_main.py
+++ b/external_server_main.py
@@ -1,14 +1,17 @@
 #!/usr/bin/env python3
 import logging
 import logging.handlers
-import json
 import sys
+import os
 
 from rich.logging import RichHandler
 
+dir_path = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(os.path.join(dir_path, "./lib/fleet-protocol/protobuf/compiled/python"))
+
 from external_server.utils import argparse_init
 from external_server.external_server import ExternalServer
-from external_server.config import Config, load_config, InvalidConfigError
+from external_server.config import load_config, InvalidConfigError
 from external_server import constants
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [project]
 name = "external_server"
-version = "1.1.9"
+version = "1.1.10"


### PR DESCRIPTION
The external server script was not executable outside of its root directory. These changes allow it to be executed from anywhere (necessary for integration testing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Simplified import structures by removing unnecessary `sys.path` modifications.
  - Updated project version number from "1.1.9" to "1.1.10".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->