### PR TITLE
Fix pip in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ WORKDIR /home/bringauto/external_server
 
 # Install python dependencies
 COPY requirements.txt /home/bringauto/external_server/requirements.txt
-RUN python3 -m pip install -r /home/bringauto/external_server/requirements.txt --break-system-packages
+RUN $PYTHON_ENVIRONMENT_PYTHON3 -m pip install -r /home/bringauto/external_server/requirements.txt
 
 # Copy project files into the docker image
 COPY external_server /home/bringauto/external_server/external_server/
@@ -67,3 +67,9 @@ COPY external_server_main.py /home/bringauto/external_server/
 # Copy module libraries
 COPY --from=mission_module_builder /home/bringauto/modules /home/bringauto/modules
 COPY --from=io_module_builder /home/bringauto/modules /home/bringauto/modules
+
+# Set the entrypoint
+# "bash" and "-c" have to be used to be able to use environment variables
+# $0 and $@ are needed to pass arguments to the script
+ENTRYPOINT [ "bash", "-c", "$PYTHON_ENVIRONMENT_PYTHON3 /home/bringauto/external_server/external_server_main.py $0 $@" ]
+CMD [ "-c", "/home/bringauto/config/for_docker.json" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ WORKDIR /home/bringauto/external_server
 
 # Install python dependencies
 COPY requirements.txt /home/bringauto/external_server/requirements.txt
-RUN $PYTHON_ENVIRONMENT_PYTHON3 -m pip install -r /home/bringauto/external_server/requirements.txt
+RUN "$PYTHON_ENVIRONMENT_PYTHON3" -m pip install -r /home/bringauto/external_server/requirements.txt
 
 # Copy project files into the docker image
 COPY external_server /home/bringauto/external_server/external_server/

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ WORKDIR /home/bringauto/external_server
 
 # Install python dependencies
 COPY requirements.txt /home/bringauto/external_server/requirements.txt
-RUN python3 -m pip install -r /home/bringauto/external_server/requirements.txt
+RUN python3 -m pip install -r /home/bringauto/external_server/requirements.txt --break-system-packages
 
 # Copy project files into the docker image
 COPY external_server /home/bringauto/external_server/external_server/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [project]
 name = "external_server"
-version = "1.1.13"
+version = "1.1.14"


### PR DESCRIPTION
pip doesn't install system packages by default on ubuntu24
added a switch to force it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated mission module to version `v1.2.11`.
	- Updated I/O module to version `v1.3.1`.
	- Enhanced Python environment setup for improved dependency management.
	- Added entrypoint configuration for executing scripts with specified arguments.

- **Bug Fixes**
	- Project version updated from `1.1.13` to `1.1.14`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->