### PR TITLE
Fix mqtt connection to broker

### DIFF
--- a/external_server/adapters/mqtt/adapter.py
+++ b/external_server/adapters/mqtt/adapter.py
@@ -306,9 +306,7 @@ class MQTTClientAdapter:
         """
         t = None if ignore_timeout else self._timeout
         try:
-            _logger.info(f"Waiting for message on topic: {self._subscribe_topic}.", self._car)
             message = self._received_msgs.get(block=True, timeout=t)
-            _logger.info(f"Received message: {message}.", self._car)
             return message
         except Empty:
             return None

--- a/external_server/adapters/mqtt/adapter.py
+++ b/external_server/adapters/mqtt/adapter.py
@@ -260,25 +260,19 @@ class MQTTClientAdapter:
         """Stop the MQTT client's event loop. If the client is already stopped, no action
         is taken.
         """
-        cli = self._mqtt_client
-        if cli._thread and cli._thread.is_alive():
-            code = self._mqtt_client.loop_stop()
-            if code == mqtt.MQTT_ERR_SUCCESS:
-                _logger.info(
-                    f"Stopped communication with MQTT broker on {self.broker_address}.", self._car
-                )
-            elif not self._mqtt_client.is_connected():
-                _logger.warning(
-                    f"Communication with MQTT broker is shut down, but error occured: {mqtt_error_from_code(code)}",
-                    self._car,
-                )
-            else:
-                _logger.error(
-                    f"Failed to stop MQTT client's loop: {mqtt_error_from_code(code)}", self._car
-                )
+        code = self._mqtt_client.loop_stop()
+        if code == mqtt.MQTT_ERR_SUCCESS:
+            _logger.info(
+                f"Stopped communication with MQTT broker on {self.broker_address}.", self._car
+            )
+        elif not self._mqtt_client.is_connected():
+            _logger.warning(
+                f"Communication with MQTT broker is shut down, but error occured: {mqtt_error_from_code(code)}",
+                self._car,
+            )
         else:
-            _logger.debug(
-                "Trying to stop MQTT client's event loop, but it is already not running.", self._car
+            _logger.error(
+                f"Failed to stop MQTT client's loop: {mqtt_error_from_code(code)}", self._car
             )
 
     def set_tls(self, ca_certs: str, certfile: str, keyfile: str) -> None:

--- a/external_server/checkers/mqtt_session.py
+++ b/external_server/checkers/mqtt_session.py
@@ -23,7 +23,7 @@ class MQTTSession:
         self._id: str = ""
         self._car_name = car_name
 
-    @property
+    @property   
     def id(self) -> str:
         """Return the session ID."""
         return self._id

--- a/external_server/logs.py
+++ b/external_server/logs.py
@@ -114,7 +114,7 @@ LOG_LEVELS: dict[Type[Exception], int] = {
 }
 
 
-def configure_logging(component_name: str, config: dict) -> None:
+def configure_logging(component_name: str, log_config: dict) -> None:
     """Configure the logging for the application.
 
     The component name is written in the log messages to identify the source of the log message.
@@ -122,7 +122,6 @@ def configure_logging(component_name: str, config: dict) -> None:
     The logging configuration is read from a JSON file. If the file is not found, a default configuration is used.
     """
 
-    log_config = config["logging"]
     logger = logging.getLogger(LOGGER_NAME)
     try:
         verbose: bool = log_config["verbose"]
@@ -155,7 +154,7 @@ def configure_logging(component_name: str, config: dict) -> None:
 
 def _log_format(component_name: str) -> str:
     log_component_name = "-".join(component_name.lower().split())
-    return f"[%(asctime)s.%(msecs)03d]\t[{log_component_name}]\t[%(levelname)s]\t%(message)s"
+    return f"[%(asctime)s.%(msecs)03d] [{log_component_name}] [%(levelname)s]\t%(message)s"
 
 
 def _log_file_name(component_name: str) -> str:

--- a/external_server/models/events.py
+++ b/external_server/models/events.py
@@ -3,7 +3,6 @@ from typing import Any
 import dataclasses
 from enum import Enum, auto
 
-
 from external_server.logs import CarLogger as _CarLogger
 
 
@@ -37,7 +36,6 @@ class EventQueue:
     def __init__(self, car: str = "") -> None:
         self._queue: _Queue[Any] = _Queue()
         self._car = car
-        logger.debug(f"Event queue '{id(self)}' has been created.", self._car)
 
     def add(self, event_type: EventType, data: Any = None) -> None:
         """Add new item to the queue."""

--- a/external_server_main.py
+++ b/external_server_main.py
@@ -18,7 +18,9 @@ def parsed_script_args() -> argparse.Namespace:
         default="./config/config.json",
         help="path to the configuration file",
     )
-    parser.add_argument("--tls", action=argparse.BooleanOptionalAction, help="use tls authentication")
+    parser.add_argument(
+        "--tls", action=argparse.BooleanOptionalAction, help="use tls authentication"
+    )
     tls = parser.add_argument_group("tls", description="if tls is used, set following arguments")
     tls.add_argument("--ca", type=str, help="path to Certificate Authority certificate files")
     tls.add_argument("--cert", type=str, help="path to PEM encoded client certificate file")
@@ -56,7 +58,7 @@ def main() -> None:
         with open(args.config) as f:
             config_dict = json.loads(f.read())
             config = load_config(args.config)
-            configure_logging("External Server", config_dict)
+            configure_logging("External Server", config_dict["logging"])
     except InvalidConfiguration as exc:
         eslogger.error(f"Invalid config: {exc}")
         print(f"Invalid config: {exc}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "external_server"
-version = "2.0.1"
+version = "2.0.2"
 
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
When reconnecting to the MQTT broker after a failed connection sequence or failed normal communication, the server occasionally got stuck in a loop of repeated starting and stopping of the MQTT client communication loop. 

This was caused by not properly stopping the communication thread of the MQTT client and, at the same time, raising an exception every time the call to the MQTT client loop_start method failed. The latter happens even in cases of a repeated call to the MQTT adapter connect method. The problem with the server getting stuck in a loop of reconnecting to the MQTT broker is solved in two ways: 
- by only logging a warning when calling loop_start of the MQTT client after the client already has existing communication thread and
- by removing the condition of the thread being alive when calling loop_stop in the MQTT adapter stop method to ensure the MQTT client always disconnects after an exception is raised during communication, including stopping and deleting the MQTT client thread.