### PR TITLE
Baf 991/more logging options in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ As an example of a filled-up config file, see the `config/config.json`. Before r
 
 Set up the logging, the MQTT connection parameters and company name and the External server behavior.
 
-- `logging` - contains the following keys:
-  - `log-path` - path to the directory where logs will be stored.
-  - `verbosity` - if `False`, logs level will be set to `INFO` and logs printed only to file. If `True`, log level is set to `DEBUG` and logs are printed both to a file and to console.
+- `logging` - contains the keys `console`and `file` for printing the logs into a console and a file, respectively. The `file` contains field `path` to set the (absolute or relative) path to the directory to store log files. Both contain the following keys:
+  - `level` - logging level as a string (`DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`). Case-insensitive.
+  - `use` - set to `True` to allow to print the logs, otherwise set to `False`.
 - `company_name` - used for MQTT topics name, should be same as in module gateway; only lowercase characters, numbers and underscores are allowed.
 - `mqtt_address` - IP address of the MQTT broker.
 - `mqtt_port` - port of the MQTT broker.

--- a/README.md
+++ b/README.md
@@ -40,13 +40,13 @@ As an example of a filled-up config file, see the `config/config.json`. Before r
 
 Set up the logging, the MQTT connection parameters and company name and the External server behavior.
 
-- `logging` - contains the keys `console`and `file` for printing the logs into a console and a file, respectively. The `file` contains field `path` to set the (absolute or relative) path to the directory to store log files. Both contain the following keys:
+- `logging` - contains the keys `console`and `file` for printing the logs into a console and a file, respectively. The `file` contains field `path` to set the (absolute or relative) path to the directory to store the logs. Both contain the following keys:
   - `level` - logging level as a string (`DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`). Case-insensitive.
   - `use` - set to `True` to allow to print the logs, otherwise set to `False`.
 - `company_name` - used for MQTT topics name, should be same as in module gateway; only lowercase characters, numbers and underscores are allowed.
 - `mqtt_address` - IP address of the MQTT broker.
 - `mqtt_port` - port of the MQTT broker.
-  ation of config for the module, any key-value pairs will be forwarded to module implementation init function; when empty or missing, empty config forwarded to init function.- `mqtt_timeout` (in seconds) - timeout for getting a message from MQTT Client.
+- `mqtt_timeout` (in seconds) - timeout for getting a message from MQTT Client.
 - `timeout` (in seconds) - Maximum time amount between Status or Command messages and receiving corresponding responses.
 - `send_invalid_command` - sends command to Module gateway even if External Server detects invalid command returned from external_server_api; affects only normal communication.
 - `sleep_duration_after_connection_refused` - if the connection to Module Gateway was refused, the External Server will sleep for a defined duration before the next connection attempt proceeds.

--- a/config/config.json
+++ b/config/config.json
@@ -1,7 +1,14 @@
 {
   "logging": {
-    "log-path": "log/",
-    "verbose": true
+    "console": {
+        "level": "debug",
+        "use": true
+    },
+    "file": {
+        "level": "debug",
+        "use": true,
+        "path": "./log/"
+    }
   },
   "company_name": "bringauto",
   "mqtt_address": "mosquitto",

--- a/config/for_docker.json
+++ b/config/for_docker.json
@@ -1,7 +1,14 @@
 {
   "logging": {
-    "log-path": "/home/bringauto/log/",
-    "verbose": true
+    "console": {
+        "level": "debug",
+        "use": true
+    },
+    "file": {
+        "level": "debug",
+        "use": true,
+        "path": "/home/bringauto/log/"
+    }
   },
   "company_name": "bringauto",
   "mqtt_address": "mosquitto",

--- a/external_server/logs.py
+++ b/external_server/logs.py
@@ -128,6 +128,9 @@ def configure_logging(component_name: str, config: _Config) -> None:
             _configure_logging_to_console(log_config.console, component_name)
         if log_config.file.use:
             _configure_logging_to_file(log_config.file, component_name)
+        logging.getLogger(LOGGER_NAME).setLevel(
+            logging.DEBUG
+        )  # This ensures the logging level will be fully determined by the handlers
     except ValueError as ve:
         logging.error(f"{component_name}: Configuration error: {ve}")
         raise

--- a/external_server/logs.py
+++ b/external_server/logs.py
@@ -12,11 +12,11 @@ from external_server.models.exceptions import (  # type: ignore
     SessionTimeout,
     UnexpectedMQTTDisconnect,
 )
+from external_server.config import ServerConfig as _Config, Logging as _Logging
 
 
 LOGGER_NAME = "external_server"
 _DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
-_log_level_by_verbosity = {False: logging.WARNING, True: logging.DEBUG}
 
 
 class _Logger(abc.ABC):
@@ -114,47 +114,67 @@ LOG_LEVELS: dict[Type[Exception], int] = {
 }
 
 
-def configure_logging(component_name: str, log_config: dict) -> None:
+def configure_logging(component_name: str, config: _Config) -> None:
     """Configure the logging for the application.
 
     The component name is written in the log messages to identify the source of the log message.
 
     The logging configuration is read from a JSON file. If the file is not found, a default configuration is used.
     """
-
-    logger = logging.getLogger(LOGGER_NAME)
     try:
-        verbose: bool = log_config["verbose"]
-        logger.setLevel(_log_level_by_verbosity[verbose])
-    except KeyError as e:
-        logging.error(f"{component_name}: Missing logging configuration. {e}")
-    except Exception as e:
-        logging.error(f"{component_name}: Could not configure logging. {e}")
+        log_config = config.logging
 
-    try:
-        # create formatter
-        formatter = logging.Formatter(_log_format(component_name), datefmt=_DATE_FORMAT)
-        # console handler
-        if verbose:
-            console_handler = logging.StreamHandler()
-            console_handler.setFormatter(formatter)
-            logger.addHandler(console_handler)
-        # file handler
-        file_path = os.path.join(log_config["log-path"], _log_file_name(component_name) + ".log")
-        file_handler = logging.handlers.RotatingFileHandler(
-            file_path, maxBytes=10485760, backupCount=5
-        )
-        file_handler.setFormatter(formatter)
-        logger.addHandler(file_handler)
-    except KeyError as e:
-        logging.error(f"{component_name}: Missing logging configuration. {e}")
+        if log_config.console.use:
+            _configure_logging_to_console(log_config.console, component_name)
+        if log_config.file.use:
+            _configure_logging_to_file(log_config.file, component_name)
+    except ValueError as ve:
+        logging.error(f"{component_name}: Configuration error: {ve}")
+        raise
     except Exception as e:
-        logging.error(f"{component_name}: Could not configure logging. {e}")
+        logging.error(f"{component_name}: Error when configuring logging: {e}")
+        raise
+
+
+def _configure_logging_to_console(config: _Logging.HandlerConfig, component_name: str):
+    """Configure the logging to the console.
+
+    The console logging is configured to use the logging level and format specified in the configuration.
+    """
+    handler = logging.StreamHandler()
+    handler.setLevel(config.level)
+    _add_formatter(handler, component_name)
+    _use_handler(handler)
+
+
+def _configure_logging_to_file(config: _Logging.HandlerConfig, component_name: str) -> None:
+    """Configure the logging to a file.
+
+    The file logging is configured to use the logging level and format specified in the configuration.
+    """
+    if not config.path:
+        raise ValueError(f"Log directory does not exist: {config.path}. Check the config file.")
+    file_path = os.path.join(config.path, _log_file_name(component_name) + ".log")
+    handler = logging.handlers.RotatingFileHandler(file_path, maxBytes=10485760, backupCount=5)
+    handler.setLevel(config.level)
+    _add_formatter(handler, component_name)
+    _use_handler(handler)
+
+
+def _add_formatter(handler: logging.Handler, component_name: str) -> None:
+    """Set the formatter for the logging handler."""
+    formatter = logging.Formatter(_log_format(component_name), datefmt=_DATE_FORMAT)
+    handler.setFormatter(formatter)
+
+
+def _use_handler(handler: logging.Handler) -> None:
+    """Add handler to the logger."""
+    logging.getLogger(LOGGER_NAME).addHandler(handler)
 
 
 def _log_format(component_name: str) -> str:
     log_component_name = "-".join(component_name.lower().split())
-    return f"[%(asctime)s.%(msecs)03d] [{log_component_name}] [%(levelname)s]\t%(message)s"
+    return f"[%(asctime)s.%(msecs)03d] [{log_component_name}] [%(levelname)s]\t %(message)s"
 
 
 def _log_file_name(component_name: str) -> str:

--- a/external_server_main.py
+++ b/external_server_main.py
@@ -2,7 +2,6 @@
 import sys
 import argparse
 import os
-import json
 
 from external_server.server import ExternalServer, eslogger
 from external_server.config import load_config, InvalidConfiguration
@@ -55,10 +54,8 @@ def main() -> None:
         sys.exit(1)
 
     try:
-        with open(args.config) as f:
-            config_dict = json.loads(f.read())
-            config = load_config(args.config)
-            configure_logging("External Server", config_dict["logging"])
+        config = load_config(args.config)
+        configure_logging("External Server", config)
     except InvalidConfiguration as exc:
         eslogger.error(f"Invalid config: {exc}")
         print(f"Invalid config: {exc}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "external_server"
-version = "2.0.2"
+version = "2.1.0"
 
 
 [tool.setuptools.packages.find]

--- a/tests/config.json
+++ b/tests/config.json
@@ -1,7 +1,14 @@
 {
-  "general-settings": {
-    "log-path": "log/",
-    "verbose": true
+  "logging": {
+    "console": {
+        "level": "debug",
+        "use": true
+    },
+    "file": {
+        "level": "debug",
+        "use": true,
+        "path": "./log/"
+    }
   },
   "company_name": "bringauto",
   "mqtt_address": "mosquitto",

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -29,6 +29,10 @@ COMMON_CONFIG = {
     "log_files_directory": ".",
     "log_files_to_keep": 5,
     "log_file_max_size_bytes": 100000,
+    "logging": {
+        "console": {"level": "DEBUG", "use": True},
+        "file": {"level": "DEBUG", "use": True, "path": "./log"},
+    },
 }
 
 CAR_CONFIG_WITHOUT_MODULES = {"company_name": "ba", "car_name": "car1", **COMMON_CONFIG}


### PR DESCRIPTION
The previous very simple logging configuration has been considered insufficient for controlling log output. 

The previous structure 
{
   "verbose": <\boolean\>,
   "log_path": \<path\>
}

has been replaced with 

{
        "console": {
            "level": \<level-name\>,
            "use":  \<boolean\>
        },
        "file": {
            "level": \<level-name\>,
            "use":  \<boolean\>,
            "path": \<path\>
        }
 }