### PR TITLE
Baf 1006/add module and line to logs

### DIFF
--- a/external_server/adapters/api/adapter.py
+++ b/external_server/adapters/api/adapter.py
@@ -306,7 +306,7 @@ class APIClientAdapter:
     def _check_forward_error_message_code(module_id: int, code: int, car: str) -> None:
         if code != _GeneralErrorCode.OK:
             _logger.error(
-                f"Module {module_id}: Error in forward_error_message function, code: {code}.", car
+                f"Module {module_id}: Error in forward_error_message function, code: {code}.",  
             )
 
     @staticmethod

--- a/external_server/adapters/mqtt/adapter.py
+++ b/external_server/adapters/mqtt/adapter.py
@@ -159,7 +159,10 @@ class MQTTClientAdapter:
         return self._timeout
 
     def connect(self) -> None:
-        """Connect to the MQTT broker."""
+        """Connect to the MQTT broker using host and port provided during initialization.
+
+        Raise an exception if the connection is refused.
+        """
         self._connect_to_broker()
         code = self._start_communication()
         if code != mqtt.MQTT_ERR_SUCCESS:

--- a/external_server/adapters/mqtt/adapter.py
+++ b/external_server/adapters/mqtt/adapter.py
@@ -322,9 +322,6 @@ class MQTTClientAdapter:
         except Empty:
             return None
 
-    def _client_thread_alive(self) -> bool:
-        return self._mqtt_client._thread is not None and self._mqtt_client._thread.is_alive()
-
     def _start_communication(self) -> int:
         self._set_up_callbacks()
         self._mqtt_client.subscribe(self._subscribe_topic, qos=_QOS)

--- a/external_server/adapters/mqtt/adapter.py
+++ b/external_server/adapters/mqtt/adapter.py
@@ -163,7 +163,7 @@ class MQTTClientAdapter:
 
         Raise an exception if the connection is refused.
         """
-        self._connect_to_broker()
+        self._set_up_connection_to_broker()
         code = self._start_communication()
         if code != mqtt.MQTT_ERR_SUCCESS:
             error = mqtt_error_from_code(code)
@@ -177,7 +177,11 @@ class MQTTClientAdapter:
                 raise ConnectionRefusedError(error)
         return code
 
-    def _connect_to_broker(self) -> None:
+    def _set_up_connection_to_broker(self) -> None:
+        """Create a connection to the MQTT broker. This is required before starting communication loop of the MQTT client.
+
+        Raise an exception if the connection is refused.
+        """
         try:
             code = self._mqtt_client.connect(self._broker_host, self._broker_port, _KEEPALIVE)
             if code == mqtt.MQTT_ERR_SUCCESS:
@@ -188,8 +192,8 @@ class MQTTClientAdapter:
         except Exception as e:
             raise ConnectionRefusedError from e
 
-    def disconnect(self) -> None:
-        """Disconnect from the MQTT broker."""
+    def disconnect(self) -> int:
+        """Disconnect from the MQTT broker. No action is taken if the MQTT client is already disconnected."""
         if self._mqtt_client.is_connected():
             code = self._mqtt_client.disconnect()
             self.stop()
@@ -201,11 +205,13 @@ class MQTTClientAdapter:
                     f"Error when disconnecting from MQTT broker. ({self.broker_address}): {error}",
                     self._car,
                 )
+            return code
         else:
             _logger.info(
                 "Trying to disconnect from MQTT broker, but not connected. No action is taken.",
                 self._car,
             )
+            return mqtt.MQTT_ERR_SUCCESS
 
     def get_connect_message(self) -> _Connect | None:
         """Get expected connect message from MQTT client.
@@ -262,13 +268,12 @@ class MQTTClientAdapter:
             raise MQTTCommunicationError(msg)
 
     def stop(self) -> None:
-        """Stop the MQTT client's event loop. If the client is already stopped, no action
-        is taken.
-        """
-        code = self._mqtt_client.loop_stop()
+        """Stop the MQTT client's event loop. If the client is already stopped, no action is taken."""
+        code = self._stop_client_loop()
         if code == mqtt.MQTT_ERR_SUCCESS:
             _logger.info(
-                f"Stopped communication with MQTT broker on {self.broker_address}.", self._car
+                f"Communication between MQTT client and broker ('{self.broker_address}') is stopped.",
+                self._car,
             )
         elif not self._mqtt_client.is_connected():
             _logger.warning(
@@ -279,6 +284,18 @@ class MQTTClientAdapter:
             _logger.error(
                 f"Failed to stop MQTT client's loop: {mqtt_error_from_code(code)}", self._car
             )
+
+    def _stop_client_loop(self) -> int:
+        """Stop the MQTT client's traffic-processing loop. If the loop is not running, no action is taken."""
+        if self._mqtt_client._thread is not None and self._mqtt_client._thread.is_alive():
+            code = self._mqtt_client.loop_stop()
+            return code
+        else:
+            _logger.warning(
+                "Attempted to stop MQTT client loop, but the loop is not running. No action is taken.",
+                self._car,
+            )
+            return mqtt.MQTT_ERR_SUCCESS
 
     def set_tls(self, ca_certs: str, certfile: str, keyfile: str) -> None:
         """Set the TLS configuration for the MQTT client.
@@ -323,6 +340,7 @@ class MQTTClientAdapter:
             return None
 
     def _start_communication(self) -> int:
+        """Set up the MQTT client traffic processing (callbacks and subscriptions) and ensure the traffic processing loop is running."""
         self._set_up_callbacks()
         self._mqtt_client.subscribe(self._subscribe_topic, qos=_QOS)
         code = self._start_client_loop()
@@ -399,7 +417,14 @@ class MQTTClientAdapter:
         self._mqtt_client.on_message = self._on_message
 
     def _start_client_loop(self) -> int:
+        """Start the MQTT client traffic-processing loop. If the loop is already running it is
+        stopped first and then started again."""
         if self._mqtt_client._thread is not None and self._mqtt_client._thread.is_alive():
+            _logger.warning(
+                "Attempted to start MQTT client traffic-processing loop, but it is already running. "
+                "Stopping the current loop and starting a new one.",
+                self._car,
+            )
             self._mqtt_client.loop_stop()
             self._mqtt_client._thread = None
         return self._mqtt_client.loop_start()

--- a/external_server/adapters/mqtt/adapter.py
+++ b/external_server/adapters/mqtt/adapter.py
@@ -169,7 +169,8 @@ class MQTTClientAdapter:
             error = mqtt_error_from_code(code)
             if self._mqtt_client.is_connected():
                 _logger.warning(
-                    f"Communication with MQTT broker on {self.broker_address} is established with error message: {error}",
+                    "External server MQTT connection - communication between client and broker "
+                    f"'{self.broker_address}' is established with error message: {error}",
                     self._car,
                 )
             else:

--- a/external_server/config.py
+++ b/external_server/config.py
@@ -87,7 +87,7 @@ class ServerConfig(BaseModel):
     sleep_duration_after_connection_refused: float = Field(ge=0)
     common_modules: dict[ModuleID, ModuleConfig]
     cars: dict[str, CarModulesConfig]
-    logging: Logging
+    logging: LoggingConfig
 
     @model_validator(mode="before")
     @classmethod
@@ -113,7 +113,7 @@ class ServerConfig(BaseModel):
         return fields
 
 
-class Logging(BaseModel):
+class LoggingConfig(BaseModel):
     console: HandlerConfig
     file: HandlerConfig
 

--- a/external_server/logs.py
+++ b/external_server/logs.py
@@ -17,6 +17,7 @@ from external_server.config import ServerConfig as _Config, Logging as _Logging
 
 LOGGER_NAME = "external_server"
 _DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
+_LOCATION_FORMAT = "[%(filename)s:%(lineno)d]"
 
 
 class _Logger(abc.ABC):
@@ -177,7 +178,7 @@ def _use_handler(handler: logging.Handler) -> None:
 
 def _log_format(component_name: str) -> str:
     log_component_name = "-".join(component_name.lower().split())
-    return f"[%(asctime)s.%(msecs)03d] [{log_component_name}] [%(levelname)s]\t %(message)s"
+    return f"[%(asctime)s.%(msecs)03d] [{log_component_name}] {_LOCATION_FORMAT} [%(levelname)s]\t %(message)s"
 
 
 def _log_file_name(component_name: str) -> str:

--- a/external_server/logs.py
+++ b/external_server/logs.py
@@ -1,4 +1,4 @@
-from typing import Type
+from typing import Type, Any
 import abc
 import logging.handlers
 import os
@@ -12,98 +12,13 @@ from external_server.models.exceptions import (  # type: ignore
     SessionTimeout,
     UnexpectedMQTTDisconnect,
 )
-from external_server.config import ServerConfig as _Config, Logging as _Logging
+from external_server.config import LoggingConfig as _Config
 
 
 LOGGER_NAME = "external_server"
+PROJECT_ROOT = os.path.dirname(os.path.dirname(__file__))
 _DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
-_LOCATION_FORMAT = "[%(filename)s:%(lineno)d]"
-
-
-class _Logger(abc.ABC):
-    """Abstract class for wrapping a logger from the Python logging module."""
-
-    def __init__(self, logger_name: str = LOGGER_NAME) -> None:
-        self._logger = logging.getLogger(logger_name)
-        self._logger.setLevel(logging.INFO)
-
-    @abc.abstractmethod
-    def debug(self, msg: str, car_name: str) -> None:
-        pass
-
-    @abc.abstractmethod
-    def info(self, msg: str, car_name: str) -> None:
-        pass
-
-    @abc.abstractmethod
-    def warning(self, msg: str, car_name: str) -> None:
-        pass
-
-    @abc.abstractmethod
-    def error(self, msg: str, car_name: str) -> None:
-        pass
-
-    @abc.abstractmethod
-    def log_on_exception(self, e: Exception, car_name: str) -> None:
-        pass
-
-
-class CarLogger(_Logger):
-    """Logger class for logging messages, forcing including the car name in the log message.
-
-    The car name is necessary to identify the source of the log message.
-    """
-
-    def debug(self, msg: str, car_name: str) -> None:
-        self._logger.debug(self._car_msg(car_name, msg))
-
-    def info(self, msg: str, car_name: str) -> None:
-        self._logger.info(self._car_msg(car_name, msg))
-
-    def warning(self, msg: str, car_name: str) -> None:
-        self._logger.warning(self._car_msg(car_name, msg))
-
-    def error(self, msg: str, car_name: str) -> None:
-        self._logger.error(self._car_msg(car_name, msg))
-
-    def log_on_exception(self, e: Exception, car_name: str) -> None:
-        log_level = LOG_LEVELS.get(type(e), logging.ERROR)
-        self._logger.log(log_level, self._car_msg(car_name, str(e)))
-
-    @staticmethod
-    def _car_msg(car_name: str, msg: str) -> str:
-        car_name = car_name.strip()
-        if car_name:
-            return f"({car_name})\t {msg}"
-        else:
-            return msg
-
-
-class ESLogger(_Logger):
-    """Logger class for logging messages at the level of the whole external server, outside of any car's context."""
-
-    def debug(self, msg: str, *args) -> None:
-        self._logger.debug(self._msg(msg))
-
-    def info(self, msg: str, *args) -> None:
-        self._logger.info(self._msg(msg))
-
-    def warning(self, msg: str, *args) -> None:
-        self._logger.warning(self._msg(msg))
-
-    def error(self, msg: str, *args) -> None:
-        self._logger.error(self._msg(msg))
-
-    def log_on_exception(self, e: Exception, *args) -> None:
-        log_level = LOG_LEVELS.get(type(e), logging.ERROR)
-        self._logger.log(log_level, self._msg(str(e)))
-
-    def _msg(self, msg: str) -> str:
-        return f"(server)\t {msg}"
-
-
 DEFAULT_EXCEPTION_LOG_LEVEL = logging.WARNING
-
 LOG_LEVELS: dict[Type[Exception], int] = {
     CommunicationException: DEFAULT_EXCEPTION_LOG_LEVEL,
     ConnectSequenceFailure: DEFAULT_EXCEPTION_LOG_LEVEL,
@@ -115,6 +30,98 @@ LOG_LEVELS: dict[Type[Exception], int] = {
 }
 
 
+class _Logger(abc.ABC):
+    """Abstract class for wrapping a logger from the Python logging module."""
+
+    def __init__(self, logger_name: str = LOGGER_NAME) -> None:
+        self._logger = logging.getLogger(logger_name)
+        self._logger.setLevel(logging.INFO)
+
+    @property
+    def logger(self) -> logging.Logger:
+        return self._logger
+
+    @abc.abstractmethod
+    def debug(self, msg: str, car_name: str) -> None:
+        pass
+
+    @abc.abstractmethod
+    def info(self, msg: str, car_name: str) -> None:
+        pass
+
+    @abc.abstractmethod
+    def warning(self, msg: str, car_name: str) -> None:
+        pass
+
+    @abc.abstractmethod
+    def error(self, msg: str, car_name: str) -> None:
+        pass
+
+    @abc.abstractmethod
+    def log_on_exception(self, e: Exception, car_name: str) -> None:
+        pass
+
+    def format_caller_info(self, caller_info: tuple[str, int, str, Any]) -> str:
+        module_path, line, _, _ = caller_info
+        module_path = os.path.relpath(module_path, PROJECT_ROOT)
+        return f"[{module_path}:{line}]"
+
+
+class CarLogger(_Logger):
+    """Logger class for logging messages, forcing including the car name in the log message.
+
+    The car name is necessary to identify the source of the log message.
+    """
+
+    def debug(self, msg: str, car_name: str) -> None:
+        self._logger.debug(self._msg(car_name, msg, self._logger.findCaller(stacklevel=2)))
+
+    def info(self, msg: str, car_name: str) -> None:
+        self._logger.info(self._msg(car_name, msg, self._logger.findCaller(stacklevel=2)))
+
+    def warning(self, msg: str, car_name: str) -> None:
+        self._logger.warning(self._msg(car_name, msg, self._logger.findCaller(stacklevel=2)))
+
+    def error(self, msg: str, car_name: str) -> None:
+        self._logger.error(self._msg(car_name, msg, self._logger.findCaller(stacklevel=2)))
+
+    def log_on_exception(self, e: Exception, car_name: str) -> None:
+        log_level = LOG_LEVELS.get(type(e), logging.ERROR)
+        self._logger.log(
+            log_level, self._msg(car_name, str(e), self._logger.findCaller(stacklevel=2))
+        )
+
+    def _msg(self, car_name: str, msg: str, caller_info: tuple[str, int, str, Any]) -> str:
+        car_name = car_name.strip()
+        if car_name:
+            return f"{self.format_caller_info(caller_info)}\t({car_name})\t{msg}"
+        else:
+            return f"{self.format_caller_info(caller_info)}\t(undefined car)\t{msg}"
+
+
+class ESLogger(_Logger):
+    """Logger class for logging messages at the level of the whole external server, outside of any car's context."""
+
+    def debug(self, msg: str, *args) -> None:
+        self._logger.debug(self._msg(msg, self._logger.findCaller(stacklevel=2)))
+
+    def info(self, msg: str, *args) -> None:
+        self._logger.info(self._msg(msg, self._logger.findCaller(stacklevel=2)))
+
+    def warning(self, msg: str, *args) -> None:
+        self._logger.warning(self._msg(msg, self._logger.findCaller(stacklevel=2)))
+
+    def error(self, msg: str, *args) -> None:
+        self._logger.error(self._msg(msg, self._logger.findCaller(stacklevel=2)))
+
+    def log_on_exception(self, e: Exception, *args) -> None:
+        log_level = LOG_LEVELS.get(type(e), logging.ERROR)
+        self._logger.log(log_level, self._msg(str(e), self._logger.findCaller(stacklevel=2)))
+
+    def _msg(self, msg: str, caller_info: tuple[str, int, str, Any]) -> str:
+        return f"{self.format_caller_info(caller_info)} (server)\t{msg}"
+
+
 def configure_logging(component_name: str, config: _Config) -> None:
     """Configure the logging for the application.
 
@@ -123,12 +130,10 @@ def configure_logging(component_name: str, config: _Config) -> None:
     The logging configuration is read from a JSON file. If the file is not found, a default configuration is used.
     """
     try:
-        log_config = config.logging
-
-        if log_config.console.use:
-            _configure_logging_to_console(log_config.console, component_name)
-        if log_config.file.use:
-            _configure_logging_to_file(log_config.file, component_name)
+        if config.console.use:
+            _configure_logging_to_console(config.console, component_name)
+        if config.file.use:
+            _configure_logging_to_file(config.file, component_name)
         logging.getLogger(LOGGER_NAME).setLevel(
             logging.DEBUG
         )  # This ensures the logging level will be fully determined by the handlers
@@ -140,7 +145,7 @@ def configure_logging(component_name: str, config: _Config) -> None:
         raise
 
 
-def _configure_logging_to_console(config: _Logging.HandlerConfig, component_name: str):
+def _configure_logging_to_console(config: _Config.HandlerConfig, component_name: str):
     """Configure the logging to the console.
 
     The console logging is configured to use the logging level and format specified in the configuration.
@@ -151,7 +156,7 @@ def _configure_logging_to_console(config: _Logging.HandlerConfig, component_name
     _use_handler(handler)
 
 
-def _configure_logging_to_file(config: _Logging.HandlerConfig, component_name: str) -> None:
+def _configure_logging_to_file(config: _Config.HandlerConfig, component_name: str) -> None:
     """Configure the logging to a file.
 
     The file logging is configured to use the logging level and format specified in the configuration.
@@ -178,7 +183,7 @@ def _use_handler(handler: logging.Handler) -> None:
 
 def _log_format(component_name: str) -> str:
     log_component_name = "-".join(component_name.lower().split())
-    return f"[%(asctime)s.%(msecs)03d] [{log_component_name}] {_LOCATION_FORMAT} [%(levelname)s]\t %(message)s"
+    return f"[%(asctime)s.%(msecs)03d] [{log_component_name}] [%(levelname)s]\t %(message)s"
 
 
 def _log_file_name(component_name: str) -> str:

--- a/external_server/models/events.py
+++ b/external_server/models/events.py
@@ -40,7 +40,7 @@ class EventQueue:
     def add(self, event_type: EventType, data: Any = None) -> None:
         """Add new item to the queue."""
         self._queue.put(Event(event_type=event_type, data=data))
-        msg = f"Adding new event: {event_type}"
+        msg = f"Adding new event to queue: {event_type}"
         if data:
             msg += f" with data: {data}"
         logger.debug(msg, self._car)

--- a/external_server/server.py
+++ b/external_server/server.py
@@ -156,9 +156,8 @@ class ExternalServer:
                     car_thread.join()
             self._car_threads.clear()
         except Exception as e:
-            carlogger.error(
-                f"Error in stopping the external server (company='{self._company}'): {e}",
-                self._company,
+            eslogger.error(
+                f"Error in stopping the external server (company='{self._company}'): {e}"
             )
 
     def set_tls(self, ca_certs: str, certfile: str, keyfile: str) -> None:

--- a/external_server_main.py
+++ b/external_server_main.py
@@ -55,7 +55,7 @@ def main() -> None:
 
     try:
         config = load_config(args.config)
-        configure_logging("External Server", config)
+        configure_logging("External Server", config.logging)
     except InvalidConfiguration as exc:
         eslogger.error(f"Invalid config: {exc}")
         print(f"Invalid config: {exc}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "external_server"
-version = "2.1.0"
+version = "2.1.1"
 
 
 [tool.setuptools.packages.find]

--- a/tests/logs/test_logging.py
+++ b/tests/logs/test_logging.py
@@ -1,0 +1,29 @@
+import unittest
+import json
+import os
+
+from external_server.logs import CarLogger, ESLogger, configure_logging, LOGGER_NAME
+from external_server.config import LoggingConfig
+
+
+PATH = os.path.dirname(os.path.dirname(__file__))
+
+
+class Test_Server_Logger(unittest.TestCase):
+
+    def setUp(self):
+        self.config = LoggingConfig(
+            console=LoggingConfig.HandlerConfig(level="debug", use=True),
+            file=LoggingConfig.HandlerConfig(level="debug", use=False),
+        )
+
+    def test_logger(self):
+        configure_logging(LOGGER_NAME, self.config)
+        logger = ESLogger(LOGGER_NAME)
+        with self.assertLogs(logger.logger, level="DEBUG") as cm:
+            logger.debug("debug message")
+            print(cm.output)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/mqtt/test_adapter.py
+++ b/tests/mqtt/test_adapter.py
@@ -227,8 +227,10 @@ class Test_Connecting_To_Broker(unittest.TestCase):
     def test_repeated_disconnect_calls_have_no_effect_after_the_first_call(self):
         self.broker.start()
         self.adapter.connect()
-        self.adapter.disconnect()
-        self.adapter.disconnect()
+        code_1 = self.adapter.disconnect()
+        code_2 = self.adapter.disconnect()
+        self.assertEqual(code_1, MQTT_ERR_SUCCESS)
+        self.assertEqual(code_2, MQTT_ERR_SUCCESS)
         self.assertEqual(self.adapter.client._state, ClientConnectionState.MQTT_CS_DISCONNECTED)
 
     def tearDown(self) -> None:

--- a/tests/mqtt/test_adapter.py
+++ b/tests/mqtt/test_adapter.py
@@ -9,7 +9,7 @@ import threading
 sys.path.append(".")
 sys.path.append("lib/fleet-protocol/protobuf/compiled/python")
 
-from paho.mqtt.client import MQTTMessage, MQTT_ERR_SUCCESS, Client
+from paho.mqtt.client import MQTTMessage, MQTT_ERR_SUCCESS, MQTT_ERR_INVAL, Client
 
 from queue import Empty
 from external_server.adapters.mqtt.adapter import (  # type: ignore
@@ -206,8 +206,10 @@ class Test_Connecting_To_Broker(unittest.TestCase):
 
     def test_repeated_connect_calls_have_no_effect_after_the_first_call(self):
         self.broker.start()
-        self.adapter.connect()
-        self.adapter.connect()
+        code_1 = self.adapter.connect()
+        code_2 = self.adapter.connect()
+        self.assertEqual(code_1, MQTT_ERR_SUCCESS)
+        self.assertEqual(code_2, MQTT_ERR_SUCCESS)
         self.assertEqual(self.adapter.client._state, ClientConnectionState.MQTT_CS_CONNECTED)
 
     def test_disconnecting_client_before_calling_connect_has_no_effect(self):


### PR DESCRIPTION
The External server logged unclear warning when there was an attempt to connect already connected MQTT client to the broker. The warning is now explicitly mentioning this. 

Logs on all levels are now augmented with the module and line, from which they originated.

Closes BAF-1006.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced logging functionality with more informative messages, including caller information.
  - Improved error handling for MQTT connection and disconnection processes.

- **Bug Fixes**
  - Clarified logging messages for event addition in the EventQueue class.
  - Refined error handling during argument parsing in the main server script.

- **Tests**
  - Added unit tests for logging functionality and improved tests for MQTT client connection handling.

- **Chores**
  - Updated project version from 2.1.0 to 2.1.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->