### PR TITLE
BAF-1019/Invalid function parameters provided

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,4 @@ external_server.egg-info
 /log/*.log
 .env
 *.coverage
-dummy.py
+dummy.*

--- a/external_server/__init__.py
+++ b/external_server/__init__.py
@@ -1,5 +1,6 @@
 import os
-from .server import CarServer, ExternalServer
+from .server.single_car import CarServer
+from .server.all_cars import ExternalServer
 
 
 PATH = os.path.dirname(os.path.abspath(os.path.dirname(__file__)))

--- a/external_server/adapters/mqtt/adapter.py
+++ b/external_server/adapters/mqtt/adapter.py
@@ -419,13 +419,15 @@ class MQTTClientAdapter:
     def _start_client_loop(self) -> int:
         """Start the MQTT client traffic-processing loop. If the loop is already running it is
         stopped first and then started again."""
-        if self._mqtt_client._thread is not None and self._mqtt_client._thread.is_alive():
+        # if self._mqtt_client._thread is not None and self._mqtt_client._thread.is_alive():
+        if self._mqtt_client._thread is not None:
             _logger.warning(
                 "Attempted to start MQTT client traffic-processing loop, but it is already running. "
-                "Stopping the current loop and starting a new one.",
+                "Stopping the current loop, starting a new one.",
                 self._car,
             )
-            self._mqtt_client.loop_stop()
+            if self._mqtt_client._thread.is_alive():
+                self._mqtt_client.loop_stop()
             self._mqtt_client._thread = None
         return self._mqtt_client.loop_start()
 

--- a/external_server/adapters/mqtt/adapter.py
+++ b/external_server/adapters/mqtt/adapter.py
@@ -417,7 +417,6 @@ class MQTTClientAdapter:
     def _start_client_loop(self) -> int:
         """Start the MQTT client traffic-processing loop. If the loop is already running it is
         stopped first and then started again."""
-        # if self._mqtt_client._thread is not None and self._mqtt_client._thread.is_alive():
         if self._mqtt_client._thread is not None:
             _logger.warning(
                 "Attempted to start MQTT client traffic-processing loop, but it is already running. "

--- a/external_server/adapters/mqtt/adapter.py
+++ b/external_server/adapters/mqtt/adapter.py
@@ -72,7 +72,7 @@ def mqtt_error_from_code(code: int) -> str:
     enum_val = _MQTTErrorCode._value2member_map_.get(code)
     if enum_val is None:
         return "Unknown error code"
-    return _error_string(enum_val).rstrip(".")
+    return "(from MQTT error code): " + _error_string(enum_val).rstrip(".")
 
 
 class MQTTClientAdapter:
@@ -163,6 +163,7 @@ class MQTTClientAdapter:
 
         Raise an exception if the connection is refused.
         """
+
         self._set_up_connection_to_broker()
         code = self._start_communication()
         if code != mqtt.MQTT_ERR_SUCCESS:
@@ -182,15 +183,12 @@ class MQTTClientAdapter:
 
         Raise an exception if the connection is refused.
         """
-        try:
-            code = self._mqtt_client.connect(self._broker_host, self._broker_port, _KEEPALIVE)
-            if code == mqtt.MQTT_ERR_SUCCESS:
-                _logger.info(f"Connected to MQTT broker on {self.broker_address}.", self._car)
-            else:
-                error = mqtt_error_from_code(code)
-                raise ConnectionRefusedError(error)
-        except Exception as e:
-            raise ConnectionRefusedError from e
+        code = self._mqtt_client.connect(self._broker_host, self._broker_port, _KEEPALIVE)
+        if code == mqtt.MQTT_ERR_SUCCESS:
+            _logger.info(f"Connected to MQTT broker on {self.broker_address}.", self._car)
+        else:
+            error = mqtt_error_from_code(code)
+            raise ConnectionRefusedError(error)
 
     def disconnect(self) -> int:
         """Disconnect from the MQTT broker. No action is taken if the MQTT client is already disconnected."""

--- a/external_server/checkers/command_checker.py
+++ b/external_server/checkers/command_checker.py
@@ -5,8 +5,8 @@ import dataclasses
 
 sys.path.append("lib/fleet-protocol/protobuf/compiled/python")
 
-from ExternalProtocol_pb2 import CommandResponse as _CommandResponse
-from InternalProtocol_pb2 import Device as _Device
+from ExternalProtocol_pb2 import CommandResponse as _CommandResponse  # type: ignore
+from InternalProtocol_pb2 import Device as _Device  # type: ignore
 
 from external_server.checkers.checker import TimeoutChecker as _Checker
 from external_server.logs import CarLogger as _CarLogger, LOGGER_NAME

--- a/external_server/checkers/mqtt_session.py
+++ b/external_server/checkers/mqtt_session.py
@@ -42,7 +42,7 @@ class MQTTSession:
         """Update the session ID."""
         if not session_id:
             raise ValueError("Session ID cannot be empty")
-        _logger.info("Setting the MQTT session ID.", self._car_name)
+        _logger.info(f"Setting the MQTT session ID to '{session_id}'.", self._car_name)
         self._id = session_id
 
     def start(self) -> None:

--- a/external_server/checkers/mqtt_session.py
+++ b/external_server/checkers/mqtt_session.py
@@ -77,4 +77,4 @@ class MQTTSession:
             self._timer_running = False
             self._timer = None
         else:
-            _logger.debug("No timer running for the current MQTT session).", self._car_name)
+            _logger.debug("No timer running for the current MQTT session.", self._car_name)

--- a/external_server/checkers/mqtt_session.py
+++ b/external_server/checkers/mqtt_session.py
@@ -23,7 +23,7 @@ class MQTTSession:
         self._id: str = ""
         self._car_name = car_name
 
-    @property   
+    @property
     def id(self) -> str:
         """Return the session ID."""
         return self._id
@@ -42,7 +42,7 @@ class MQTTSession:
         """Update the session ID."""
         if not session_id:
             raise ValueError("Session ID cannot be empty")
-        _logger.info(f"Updating session ID from '{self._id}' to '{session_id}'.", self._car_name)
+        _logger.info("Setting the MQTT session ID.", self._car_name)
         self._id = session_id
 
     def start(self) -> None:
@@ -52,13 +52,11 @@ class MQTTSession:
             self._timer.start()
             self._timer_running = True
             _logger.debug(
-                f"Started timer for MQTT session (id='{self._id}') with timeout set to {self._checker.timeout}.",
+                f"Started timer for the current MQTT session with timeout set to {self._checker.timeout}.",
                 self._car_name,
             )
         else:
-            _logger.warning(
-                f"Timer already running for MQTT session (id='{self._id}').", self._car_name
-            )
+            _logger.warning("Timer already running for the current MQTT session.", self._car_name)
 
     def reset_timer(self) -> None:
         """Resets the checker's timer.
@@ -71,7 +69,7 @@ class MQTTSession:
     def stop(self) -> None:
         """Stops the checker's timer."""
         if self._timer_running and self._timer is not None:
-            _logger.info(f"Stopping timer for MQTT session (id='{self._id}').", self._car_name)
+            _logger.info("Stopping timer for the current MQTT session.", self._car_name)
             if self._timer.is_alive():
                 self._timer.cancel()
                 self._timer.join()
@@ -79,4 +77,4 @@ class MQTTSession:
             self._timer_running = False
             self._timer = None
         else:
-            _logger.debug(f"No timer running for MQTT session (id='{self._id}').", self._car_name)
+            _logger.debug("No timer running for the current MQTT session).", self._car_name)

--- a/external_server/server/all_cars.py
+++ b/external_server/server/all_cars.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+import sys
+import threading
+
+sys.path.append("lib/fleet-protocol/protobuf/compiled/python")
+
+from ExternalProtocol_pb2 import (  # type: ignore
+    CommandResponse as _CommandResponse,
+    Connect as _Connect,
+    Status as _Status,
+)
+from external_server.logs import ESLogger as _ESLogger, LOGGER_NAME as _LOGGER_NAME
+from external_server.checkers.command_checker import (
+    PublishedCommandChecker as _PublishedCommandChecker,
+)
+from external_server.checkers.status_checker import StatusChecker as _StatusChecker
+from external_server.adapters.mqtt.adapter import MQTTClientAdapter as _MQTTClientAdapter
+from external_server.config import CarConfig as _CarConfig, ServerConfig as _ServerConfig
+from external_server.models.events import EventType as _EventType, EventQueue as _EventQueue
+from external_server.server.single_car import CarServer
+
+
+logger = _ESLogger(_LOGGER_NAME)
+ExternalClientMessage = _Connect | _Status | _CommandResponse
+
+
+class ExternalServer:
+    """This class is the implementation of the external server.
+
+    It maintains instances of the CarServer class for each car defined in the configuration.
+    """
+
+    def __init__(self, config: _ServerConfig) -> None:
+        self._car_servers: dict[str, CarServer] = {}
+        self._car_threads: dict[str, threading.Thread] = dict()
+        self._company = config.company_name
+        for car_name in config.cars:
+            event_queue = _EventQueue(car_name)
+            status_checker = _StatusChecker(config.timeout, event_queue, car_name)
+            command_checker = _PublishedCommandChecker(config.timeout, event_queue, car_name)
+            mqtt_adapter = _MQTTClientAdapter(
+                broker_host=config.mqtt_address,
+                port=config.mqtt_port,
+                timeout=config.timeout,
+                mqtt_timeout=config.mqtt_timeout,
+                car=car_name,
+                company=self._company,
+                event_queue=event_queue,
+            )
+
+            self._car_servers[car_name] = CarServer(
+                config=_CarConfig.from_server_config(car_name, config),
+                event_queue=event_queue,
+                status_checker=status_checker,
+                command_checker=command_checker,
+                mqtt_adapter=mqtt_adapter,
+            )
+
+    def car_servers(self) -> dict[str, CarServer]:
+        """Return parts of the external server responsible for each car defined in configuration."""
+        return self._car_servers.copy()
+
+    def start(self) -> None:
+        """Start the external server.
+
+        For reach car defined in the configuration, create a separate thread and inside that,
+        start an instance of the CarServer class.
+        """
+        for car in self._car_servers:
+            self._car_threads[car] = threading.Thread(target=self._car_servers[car].start)
+        for t in self._car_threads.values():
+            t.start()
+
+    def stop(self, reason: str = "") -> None:
+        """Stop the external server.
+
+        For each car defined in the configuration, stop the CarServer instance.
+        """
+        try:
+            for car_server in self.car_servers().values():
+                car_server.stop(reason)
+                car_server._event_queue.add(_EventType.SERVER_STOPPED)
+            for car_thread in self._car_threads.values():
+                if car_thread.is_alive():
+                    car_thread.join()
+            self._car_threads.clear()
+        except Exception as e:
+            logger.error(f"Error in stopping the external server (company='{self._company}'): {e}")
+
+    def set_tls(self, ca_certs: str, certfile: str, keyfile: str) -> None:
+        """Set the TLS security to the MQTT client for each car server."""
+        for car_server in self._car_servers.values():
+            car_server.tls_set(ca_certs, certfile, keyfile)

--- a/external_server/server/single_car.py
+++ b/external_server/server/single_car.py
@@ -428,15 +428,7 @@ class CarServer:
         Raise exception if the connection fails.
         """
         logger.info("Connecting to MQTT broker.", self._car_name)
-        try:
-            self._mqtt.connect()
-        except Exception as e:
-            str_e = str(e)
-            print("=" * len(str_e))
-            print(str_e)
-            print("Is connected:", self._mqtt.is_connected)
-            print("=" * len(str_e))
-            raise
+        self._mqtt.connect()
         self._set_state(ServerState.CONNECTED)
 
     def _get_and_send_first_commands(self) -> None:
@@ -805,7 +797,7 @@ class CarServer:
             if not self._running:
                 self._set_running_flag(True)
             self._init_sequence()
-        except Exception:
+        except:
             self._set_state(ServerState.ERROR)
             raise
 

--- a/external_server/server/single_car.py
+++ b/external_server/server/single_car.py
@@ -428,7 +428,15 @@ class CarServer:
         Raise exception if the connection fails.
         """
         logger.info("Connecting to MQTT broker.", self._car_name)
-        self._mqtt.connect()
+        try:
+            self._mqtt.connect()
+        except Exception as e:
+            str_e = str(e)
+            print("=" * len(str_e))
+            print(str_e)
+            print("Is connected:", self._mqtt.is_connected)
+            print("=" * len(str_e))
+            raise
         self._set_state(ServerState.CONNECTED)
 
     def _get_and_send_first_commands(self) -> None:

--- a/external_server/server/single_car.py
+++ b/external_server/server/single_car.py
@@ -733,11 +733,6 @@ class CarServer:
         info = f"Received status, counter={status.messageCounter}."
         logger.info(info, self._car_name)
 
-    def _log_and_set_error(self, exception: Exception, car_name: str = "") -> None:
-        """Log the exception and raise it. Set the server's state to ERROR."""
-        logger.log_on_exception(exception, car_name)
-        self._set_state(ServerState.ERROR)
-
     def _module_and_device(self, message: _Status) -> tuple[_ServerModule | None, _Device | None]:
         """Return server module and device referenced by the status messages.
 

--- a/external_server_main.py
+++ b/external_server_main.py
@@ -54,7 +54,7 @@ def main() -> None:
         sys.exit(1)
 
     try:
-        config = load_config(args.config)
+        config = load_config(args   .config)
         configure_logging("External Server", config.logging)
     except InvalidConfiguration as exc:
         eslogger.error(f"Invalid config: {exc}")

--- a/external_server_main.py
+++ b/external_server_main.py
@@ -3,7 +3,7 @@ import sys
 import argparse
 import os
 
-from external_server.server import ExternalServer, eslogger
+from external_server.server.all_cars import ExternalServer, logger
 from external_server.config import load_config, InvalidConfiguration
 from external_server.logs import configure_logging
 
@@ -49,19 +49,19 @@ def main() -> None:
     try:
         args = parsed_script_args()
     except argparse.ArgumentError as exc:
-        eslogger.error(f"Invalid arguments. {exc}")
+        logger.error(f"Invalid arguments. {exc}")
         print(f"Invalid arguments. {exc}")
         sys.exit(1)
 
     try:
-        config = load_config(args   .config)
+        config = load_config(args.config)
         configure_logging("External Server", config.logging)
     except InvalidConfiguration as exc:
-        eslogger.error(f"Invalid config: {exc}")
+        logger.error(f"Invalid config: {exc}")
         print(f"Invalid config: {exc}")
         sys.exit(1)
 
-    eslogger.info(f"Loaded config:\n{config.model_dump_json(indent=4)}")
+    logger.info(f"Loaded config:\n{config.model_dump_json(indent=4)}")
     server = ExternalServer(config)
     if args.tls:
         server.set_tls(args.ca, args.cert, args.key)

--- a/tests/server/mutilple_cars/test_multiple_cars.py
+++ b/tests/server/mutilple_cars/test_multiple_cars.py
@@ -10,15 +10,9 @@ from ExternalProtocol_pb2 import Status  # type: ignore
 from external_server.server.single_car import ServerState
 from external_server.server.all_cars import ExternalServer
 from external_server.models.messages import connect_msg, status, cmd_response
-from InternalProtocol_pb2 import Device as _Device  # type: ignore
-from ExternalProtocol_pb2 import Status, CommandResponse  # type: ignore
 
 from tests.utils import get_test_server
 from tests.utils.mqtt_broker import MQTTBrokerTest
-
-
-def _device_status(device: _Device, status_data: bytes = b"") -> DeviceStatus:
-    return DeviceStatus(device=device, statusData=status_data)
 
 
 def wait_for_server_connection(

--- a/tests/server/mutilple_cars/test_multiple_cars.py
+++ b/tests/server/mutilple_cars/test_multiple_cars.py
@@ -111,41 +111,5 @@ class Test_Failed_Connection_With_Valid_Connect_Message_For_Single_Car(unittest.
         self.broker.stop()
 
 
-class Test_Failed_Connection_With_Valid_Connect_Message_For_Two_Cars(unittest.TestCase):
-
-    def setUp(self):
-        self.es = get_test_server("x", "car_a", "car_b", timeout=0.5, mqtt_timeout=0.7)
-        self.broker = MQTTBrokerTest(start=True)
-        self.device = Device(module=1000, deviceType=0, deviceName="TestDevice", deviceRole="test")
-
-    def test_connect_message_arrives_for_both_cars(self):
-        broker = self.broker
-        server_a = self.es.car_servers()["car_a"]
-        server_b = self.es.car_servers()["car_b"]
-        topic_a = server_a.mqtt.subscribe_topic
-        topic_b = server_b.mqtt.subscribe_topic
-        supported_status = _device_status(self.device)
-
-        self.es.start()
-        time.sleep(0.51)
-        broker.publish(topic_a, connect_msg("id", "company", [self.device]))
-        broker.publish(topic_b, connect_msg("id", "company", [self.device]))
-
-        time.sleep(0.5)
-        broker.publish(topic_a, connect_msg("id", "company", [self.device]))
-        broker.publish(topic_b, connect_msg("tid", "company", [self.device]))
-        broker.publish(topic_a, status("id", Status.CONNECTING, 0, supported_status))
-        broker.publish(topic_b, status("id", Status.CONNECTING, 0, supported_status))
-
-        broker.publish(topic_a, cmd_response("id", 0, CommandResponse.OK))
-        broker.publish(topic_b, cmd_response("id", 0, CommandResponse.OK))
-
-        time.sleep(50)
-
-    def tearDown(self):
-        self.es.stop()
-        self.broker.stop()
-
-
 if __name__ == "__main__":  # pragma: no cover
     unittest.main()

--- a/tests/server/mutilple_cars/test_multiple_cars.py
+++ b/tests/server/mutilple_cars/test_multiple_cars.py
@@ -9,8 +9,8 @@ from InternalProtocol_pb2 import (  # type: ignore
     DeviceStatus,
 )
 from ExternalProtocol_pb2 import Status  # type: ignore
-
-from external_server.server import ServerState, ExternalServer
+from external_server.server.single_car import ServerState
+from external_server.server.all_cars import ExternalServer
 from external_server.models.messages import connect_msg, status, cmd_response
 
 from tests.utils import get_test_server

--- a/tests/server/single_car/single_communication_attempt/test_command.py
+++ b/tests/server/single_car/single_communication_attempt/test_command.py
@@ -8,7 +8,7 @@ sys.path.append("lib/fleet-protocol/protobuf/compiled/python")
 
 from InternalProtocol_pb2 import Device  # type: ignore
 from ExternalProtocol_pb2 import CommandResponse, ExternalServer as ExternalServerMsg  # type: ignore
-from external_server.server import eslogger as es_logger
+from external_server.server.all_cars import logger as es_logger
 from external_server.checkers.command_checker import logger as command_checker_logger
 from external_server.models.structures import HandledCommand
 from external_server.models.messages import cmd_response

--- a/tests/server/single_car/single_communication_attempt/test_connect_sequence.py
+++ b/tests/server/single_car/single_communication_attempt/test_connect_sequence.py
@@ -16,10 +16,11 @@ from ExternalProtocol_pb2 import (  # type: ignore
 )
 from external_server.models.exceptions import ConnectSequenceFailure, CommunicationException
 from external_server.models.devices import DevicePy, device_status as _device_status
-from tests.utils.mqtt_broker import MQTTBrokerTest
-from tests.utils import get_test_car_server
 from external_server.models.messages import connect_msg, status, cmd_response
 from external_server.logs import LOGGER_NAME
+
+from tests.utils.mqtt_broker import MQTTBrokerTest
+from tests.utils import get_test_car_server
 
 
 logging.getLogger(LOGGER_NAME).setLevel(logging.DEBUG)

--- a/tests/server/single_car/single_communication_attempt/test_connect_sequence.py
+++ b/tests/server/single_car/single_communication_attempt/test_connect_sequence.py
@@ -7,7 +7,7 @@ import logging
 
 sys.path.append(".")
 
-from external_server.server import ServerState
+from external_server.server.single_car import ServerState
 from InternalProtocol_pb2 import Device  # type: ignore
 from ExternalProtocol_pb2 import (  # type: ignore
     ExternalServer as ExternalServerMsg,

--- a/tests/server/single_car/single_communication_attempt/test_normal_communication.py
+++ b/tests/server/single_car/single_communication_attempt/test_normal_communication.py
@@ -8,7 +8,8 @@ import threading
 
 sys.path.append(".")
 
-from external_server.server import CarServer, ServerState, eslogger as _logger
+from external_server.server.single_car import CarServer, ServerState
+from external_server.server.all_cars import logger as _logger
 from external_server.models.structures import Buffer
 from InternalProtocol_pb2 import Device, DeviceStatus  # type: ignore
 from ExternalProtocol_pb2 import (  # type: ignore

--- a/tests/server/single_car/single_communication_attempt/test_status.py
+++ b/tests/server/single_car/single_communication_attempt/test_status.py
@@ -9,7 +9,7 @@ sys.path.append("lib/fleet-protocol/protobuf/compiled/python")
 
 from ExternalProtocol_pb2 import Status, ExternalServer as ExternalServerMsg  # type: ignore
 from InternalProtocol_pb2 import Device, DeviceStatus  # type: ignore
-from external_server.server import eslogger as _logger
+from external_server.server.all_cars import logger as _logger
 from tests.utils import get_test_car_server
 from tests.utils.mqtt_broker import MQTTBrokerTest
 from external_server.models.messages import status, status_response

--- a/tests/server/single_car/single_communication_attempt/test_unexpected_mqtt_disconnection.py
+++ b/tests/server/single_car/single_communication_attempt/test_unexpected_mqtt_disconnection.py
@@ -11,7 +11,7 @@ from ExternalProtocol_pb2 import (  # type: ignore
     ExternalServer as ExternalServerMsg,
     Status,
 )
-from external_server.server import ServerState
+from external_server.server.single_car import ServerState
 from external_server.models.exceptions import UnexpectedMQTTDisconnect
 from external_server.models.events import Event, EventType
 from external_server.models.messages import cmd_response, connect_msg, status

--- a/tests/server/single_car/test_connect_sequence.py
+++ b/tests/server/single_car/test_connect_sequence.py
@@ -16,7 +16,7 @@ from ExternalProtocol_pb2 import (  # type: ignore
     Status as _Status,
 )
 from external_server.config import CarConfig, ModuleConfig
-from external_server.server import CarServer
+from external_server.server.single_car import CarServer
 from external_server.models.messages import (
     connect_msg,
     status,

--- a/tests/server/single_car/test_server_creation.py
+++ b/tests/server/single_car/test_server_creation.py
@@ -8,7 +8,7 @@ sys.path.append("lib/fleet-protocol/protobuf/compiled/python")
 from pydantic import FilePath
 
 from external_server.config import CarConfig, ModuleConfig
-from external_server.server import CarServer, ServerState
+from external_server.server.single_car import CarServer, ServerState
 from external_server.models.events import EventQueue
 from external_server.adapters.mqtt.adapter import MQTTClientAdapter
 from external_server.checkers.command_checker import PublishedCommandChecker

--- a/tests/tls/test_tls_setup.py
+++ b/tests/tls/test_tls_setup.py
@@ -7,7 +7,7 @@ sys.path.append(".")
 
 from pydantic import FilePath
 from external_server.config import CarConfig, ModuleConfig
-from external_server.server import CarServer
+from external_server.server.single_car import CarServer
 from external_server.adapters.mqtt.adapter import MQTTClientAdapter
 from tests.utils import EXAMPLE_MODULE_SO_LIB_PATH, CAR_CONFIG_WITHOUT_MODULES
 from external_server.models.events import EventQueue


### PR DESCRIPTION
The external server (running as a component of the Fleet Protocol) often produced error logs containing "Invalid function parameters provided". This problem arises from calling the connect method of the MQTT Client (class in the paho.mqtt package)  while the Client still has _thread attribute not equal to None (it also happens when calling disconnect, when _thread is already None).
 
This required removing the condition that the MQTT client thread must be alive to be deleted and created again. Now it is always done when connecting to the broker (the thread is set to None and then created again).

Also, in the MQTTClientAdapter._set_up_connection_to_broker method, any exception raised when calling mqtt_client.connect method is now simply re-raised instead of being replaced by ConnectionRefusedError.  This part of the code was causing empty error logs.

Closes BAF-1019

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a new `ExternalServer` class for managing multiple car servers
	- Introduced enhanced MQTT client thread management

- **Bug Fixes**
	- Improved error handling and logging in MQTT client adapter
	- Simplified connection management logic for MQTT clients

- **Refactor**
	- Restructured server module organization
	- Consolidated logging mechanisms across multiple files
	- Updated import paths for server-related classes

- **Chores**
	- Updated `.gitignore` to use a more generic file matching pattern
	- Added type ignore comments for specific imports
<!-- end of auto-generated comment: release notes by coderabbit.ai -->