### PR TITLE
Fixes after receiving error logs from the external server

### DIFF
--- a/external_server/adapters/api/adapter.py
+++ b/external_server/adapters/api/adapter.py
@@ -41,7 +41,7 @@ class APIClientAdapter:
         - `car` - car name, which will be forwarded as second key-value to API
         """
         self._lib_path = config.lib_path.absolute().as_posix()
-        self._config = {"company_name": company, "car_name": car}
+        self._config: dict[str, str | int] = {"company_name": company, "car_name": car}
         self._config.update(config.config)
         self._library = _ModuleLibrary(lib_path=str(config.lib_path), config=self._config)
         self._car = car
@@ -52,7 +52,7 @@ class APIClientAdapter:
 
     @property
     def company(self) -> str:
-        return self._config.get("company_name", "")
+        return str(self._config.get("company_name", ""))
 
     @property
     def context(self):
@@ -300,7 +300,9 @@ class APIClientAdapter:
     def _check_forward_status_code(module_id: int, code: int, car: str) -> None:
         if code != _GeneralErrorCode.OK:
             _logger.error(
-                f"Module {module_id}: Error in forward_status function, code: {code}.", car, 1
+                f"Module {module_id}: Error in forward_status function, code: {code}.",
+                car,
+                stack_level_up=1,
             )
 
     @staticmethod
@@ -309,7 +311,7 @@ class APIClientAdapter:
             _logger.error(
                 f"Module {module_id}: Error in forward_error_message function, code: {code}.",
                 car,
-                1,
+                stack_level_up=1,
             )
 
     @staticmethod
@@ -318,7 +320,7 @@ class APIClientAdapter:
             _logger.warning(
                 f"Module {device_id.module}: Device {device_id} not not among conected devices, code: {code}.",
                 car,
-                1,
+                stack_level_up=1,
             )
         elif code == _EsErrorCode.CONTEXT_INCORRECT:
             _logger.error(f"Module {device_id.module}: Context incorrect, code: {code}.", car, 1)
@@ -326,12 +328,14 @@ class APIClientAdapter:
             _logger.error(
                 f"Module {device_id.module}: Error in device_disconnected function, code: {code}.",
                 car,
-                1,
+                stack_level_up=1,
             )
 
     @staticmethod
     def _check_command_ack_code(module_id: int, code: int, car: str) -> None:
         if code != _GeneralErrorCode.OK:
             _logger.error(
-                f"Module {module_id}: Error in command_ack function, code: {code}.", car, 1
+                f"Module {module_id}: Error in command_ack function, code: {code}.",
+                car,
+                stack_level_up=1,
             )

--- a/external_server/adapters/api/adapter.py
+++ b/external_server/adapters/api/adapter.py
@@ -13,6 +13,7 @@ from external_server.models.structures import (
 )
 from external_server.models.structures import (
     GeneralErrorCode as _GeneralErrorCode,
+    EsErrorCode as _EsErrorCode,
 )
 from external_server.models.devices import device_repr
 from external_server.config import ModuleConfig
@@ -113,7 +114,7 @@ class APIClientAdapter:
         """
         device_identification = self._create_device_identification(device)
         code = self._library.device_disconnected(disconnect_types, device_identification)
-        self._check_device_disconnected_code(device.module, code, self._car)
+        self.check_device_disconnected_code(device, code, self._car)
         return code
 
     def _create_device_identification(self, device: _Device) -> DeviceIdentification:
@@ -299,24 +300,38 @@ class APIClientAdapter:
     def _check_forward_status_code(module_id: int, code: int, car: str) -> None:
         if code != _GeneralErrorCode.OK:
             _logger.error(
-                f"Module {module_id}: Error in forward_status function, code: {code}.", car
+                f"Module {module_id}: Error in forward_status function, code: {code}.", car, 1
             )
 
     @staticmethod
     def _check_forward_error_message_code(module_id: int, code: int, car: str) -> None:
         if code != _GeneralErrorCode.OK:
             _logger.error(
-                f"Module {module_id}: Error in forward_error_message function, code: {code}.", car
+                f"Module {module_id}: Error in forward_error_message function, code: {code}.",
+                car,
+                1,
             )
 
     @staticmethod
-    def _check_device_disconnected_code(module_id: int, code: int, car: str) -> None:
-        if code != _GeneralErrorCode.OK:
+    def check_device_disconnected_code(device_id: _Device, code: int, car: str) -> None:
+        if code == _GeneralErrorCode.NOT_OK:
+            _logger.warning(
+                f"Module {device_id.module}: Device {device_id} not not among conected devices, code: {code}.",
+                car,
+                1,
+            )
+        elif code == _EsErrorCode.CONTEXT_INCORRECT:
+            _logger.error(f"Module {device_id.module}: Context incorrect, code: {code}.", car, 1)
+        elif code != _GeneralErrorCode.OK:
             _logger.error(
-                f"Module {module_id}: Error in device_disconnected function, code: {code}.", car
+                f"Module {device_id.module}: Error in device_disconnected function, code: {code}.",
+                car,
+                1,
             )
 
     @staticmethod
     def _check_command_ack_code(module_id: int, code: int, car: str) -> None:
         if code != _GeneralErrorCode.OK:
-            _logger.error(f"Module {module_id}: Error in command_ack function, code: {code}.", car)
+            _logger.error(
+                f"Module {module_id}: Error in command_ack function, code: {code}.", car, 1
+            )

--- a/external_server/adapters/api/adapter.py
+++ b/external_server/adapters/api/adapter.py
@@ -306,7 +306,7 @@ class APIClientAdapter:
     def _check_forward_error_message_code(module_id: int, code: int, car: str) -> None:
         if code != _GeneralErrorCode.OK:
             _logger.error(
-                f"Module {module_id}: Error in forward_error_message function, code: {code}.",  
+                f"Module {module_id}: Error in forward_error_message function, code: {code}.", car
             )
 
     @staticmethod

--- a/external_server/adapters/mqtt/adapter.py
+++ b/external_server/adapters/mqtt/adapter.py
@@ -201,14 +201,20 @@ class MQTTClientAdapter:
         if self._mqtt_client.is_connected():
             code = self._mqtt_client.disconnect()
             self.stop()
-            if code == mqtt.MQTT_ERR_SUCCESS:
-                _logger.info(f"Disconnected from MQTT broker: {self.broker_address}", self._car)
-            else:
-                error = mqtt_error_from_code(code)
-                _logger.error(
-                    f"Error when disconnecting from MQTT broker. ({self.broker_address}): {error}",
-                    self._car,
-                )
+            match code:
+                case mqtt.MQTT_ERR_SUCCESS:
+                    _logger.info(f"Disconnected from MQTT broker: {self.broker_address}", self._car)
+                case mqtt.MQTT_ERR_NO_CONN:
+                    _logger.warning(
+                        "Trying to disconnect from MQTT broker, but not connected. No action is taken.",
+                        self._car,
+                    )
+                case _:
+                    error = mqtt_error_from_code(code)
+                    _logger.error(
+                        f"Error when disconnecting from MQTT broker. ({self.broker_address}): {error}",
+                        self._car,
+                    )
             return code
         else:
             _logger.info(

--- a/external_server/logs.py
+++ b/external_server/logs.py
@@ -42,23 +42,23 @@ class _Logger(abc.ABC):
         return self._logger
 
     @abc.abstractmethod
-    def debug(self, msg: str, car_name: str) -> None:
+    def debug(self, msg: str, car_name: str, stack_level_up: int = 0) -> None:
         pass
 
     @abc.abstractmethod
-    def info(self, msg: str, car_name: str) -> None:
+    def info(self, msg: str, car_name: str, stack_level_up: int = 0) -> None:
         pass
 
     @abc.abstractmethod
-    def warning(self, msg: str, car_name: str) -> None:
+    def warning(self, msg: str, car_name: str, stack_level_up: int = 0) -> None:
         pass
 
     @abc.abstractmethod
-    def error(self, msg: str, car_name: str) -> None:
+    def error(self, msg: str, car_name: str, stack_level_up: int = 0) -> None:
         pass
 
     @abc.abstractmethod
-    def log_on_exception(self, e: Exception, car_name: str) -> None:
+    def log_on_exception(self, e: Exception, car_name: str, stack_level_up: int = 0) -> None:
         pass
 
     def format_caller_info(self, caller_info: tuple[str, int, str, Any]) -> str:
@@ -73,22 +73,31 @@ class CarLogger(_Logger):
     The car name is necessary to identify the source of the log message.
     """
 
-    def debug(self, msg: str, car_name: str) -> None:
-        self._logger.debug(self._msg(car_name, msg, self._logger.findCaller(stacklevel=2)))
+    def debug(self, msg: str, car_name: str, stack_level_up: int = 0) -> None:
+        self._logger.debug(
+            self._msg(car_name, msg, self._logger.findCaller(stacklevel=2 + stack_level_up))
+        )
 
-    def info(self, msg: str, car_name: str) -> None:
-        self._logger.info(self._msg(car_name, msg, self._logger.findCaller(stacklevel=2)))
+    def info(self, msg: str, car_name: str, stack_level_up: int = 0) -> None:
+        self._logger.info(
+            self._msg(car_name, msg, self._logger.findCaller(stacklevel=2 + stack_level_up))
+        )
 
-    def warning(self, msg: str, car_name: str) -> None:
-        self._logger.warning(self._msg(car_name, msg, self._logger.findCaller(stacklevel=2)))
+    def warning(self, msg: str, car_name: str, stack_level_up: int = 0) -> None:
+        self._logger.warning(
+            self._msg(car_name, msg, self._logger.findCaller(stacklevel=2 + stack_level_up))
+        )
 
-    def error(self, msg: str, car_name: str) -> None:
-        self._logger.error(self._msg(car_name, msg, self._logger.findCaller(stacklevel=2)))
+    def error(self, msg: str, car_name: str, stack_level_up: int = 0) -> None:
+        self._logger.error(
+            self._msg(car_name, msg, self._logger.findCaller(stacklevel=2 + stack_level_up))
+        )
 
-    def log_on_exception(self, e: Exception, car_name: str) -> None:
+    def log_on_exception(self, e: Exception, car_name: str, stack_level_up: int = 0) -> None:
         log_level = LOG_LEVELS.get(type(e), logging.ERROR)
         self._logger.log(
-            log_level, self._msg(car_name, str(e), self._logger.findCaller(stacklevel=2))
+            log_level,
+            self._msg(car_name, str(e), self._logger.findCaller(stacklevel=2 + stack_level_up)),
         )
 
     def _msg(self, car_name: str, msg: str, caller_info: tuple[str, int, str, Any]) -> str:
@@ -102,21 +111,23 @@ class CarLogger(_Logger):
 class ESLogger(_Logger):
     """Logger class for logging messages at the level of the whole external server, outside of any car's context."""
 
-    def debug(self, msg: str, *args) -> None:
-        self._logger.debug(self._msg(msg, self._logger.findCaller(stacklevel=2)))
+    def debug(self, msg: str, *args, stack_level_up: int = 0) -> None:
+        self._logger.debug(self._msg(msg, self._logger.findCaller(stacklevel=2 + stack_level_up)))
 
-    def info(self, msg: str, *args) -> None:
-        self._logger.info(self._msg(msg, self._logger.findCaller(stacklevel=2)))
+    def info(self, msg: str, *args, stack_level_up: int = 0) -> None:
+        self._logger.info(self._msg(msg, self._logger.findCaller(stacklevel=2 + stack_level_up)))
 
-    def warning(self, msg: str, *args) -> None:
-        self._logger.warning(self._msg(msg, self._logger.findCaller(stacklevel=2)))
+    def warning(self, msg: str, *args, stack_level_up: int = 0) -> None:
+        self._logger.warning(self._msg(msg, self._logger.findCaller(stacklevel=2 + stack_level_up)))
 
-    def error(self, msg: str, *args) -> None:
-        self._logger.error(self._msg(msg, self._logger.findCaller(stacklevel=2)))
+    def error(self, msg: str, *args, stack_level_up: int = 0) -> None:
+        self._logger.error(self._msg(msg, self._logger.findCaller(stacklevel=2 + stack_level_up)))
 
-    def log_on_exception(self, e: Exception, *args) -> None:
+    def log_on_exception(self, e: Exception, *args, stack_level_up: int = 0) -> None:
         log_level = LOG_LEVELS.get(type(e), logging.ERROR)
-        self._logger.log(log_level, self._msg(str(e), self._logger.findCaller(stacklevel=2)))
+        self._logger.log(
+            log_level, self._msg(str(e), self._logger.findCaller(stacklevel=2 + stack_level_up))
+        )
 
     def _msg(self, msg: str, caller_info: tuple[str, int, str, Any]) -> str:
         return f"{self.format_caller_info(caller_info)} (server)\t{msg}"

--- a/external_server/server/single_car.py
+++ b/external_server/server/single_car.py
@@ -307,8 +307,10 @@ class CarServer:
         self._command_checker.reset()
         self._status_checker.reset()
         for device in self._known_devices.list_connected():
-            module_adapter = self._modules[device.module_id].api
-            module_adapter.device_disconnected(DisconnectTypes.timeout, device.to_device())
+            module = self._modules.get(device.module_id, None)
+            if module:
+                module_adapter = module.api
+                module_adapter.device_disconnected(DisconnectTypes.timeout, device.to_device())
         self._known_devices.clear()
         self._event_queue.clear()
 

--- a/external_server/server/single_car.py
+++ b/external_server/server/single_car.py
@@ -538,8 +538,12 @@ class CarServer:
                     status_ok = False
             case _Status.DISCONNECT:
                 logger.info(
-                    f"Received status with a disconnect message for device {device_repr(device)}.", self._car_name
+                    f"Received status with a disconnect message for device {device_repr(device)}.",
+                    self._car_name,
                 )
+                if not self._known_devices.is_connected(device):
+                    logger.warning("Device is already disconnected.", self._car_name)
+                    status_ok = False
             case _:
                 logger.warning(
                     f"Unknown device state: {status.deviceState}. Ignoring status.", self._car_name

--- a/tests/server/single_car/single_communication_attempt/test_status.py
+++ b/tests/server/single_car/single_communication_attempt/test_status.py
@@ -113,7 +113,7 @@ class Test_Handling_Checked_Status_From_Disconnected_Device(unittest.TestCase):
         self.es._add_connected_devices(self.device)
         self.es._mqtt.session.set_id("session_id")
 
-    def test_connecting_state_connects_the_device_and_send_response(self, mock: Mock):
+    def test_connecting_state_connects_the_device_and_sends_response(self, mock: Mock):
         self.es._known_devices.not_connected(self.device)
         mock.side_effect = self.publish
         self.assertFalse(self.es._known_devices.is_connected(self.device))

--- a/tests/server/single_car/single_communication_attempt/test_status.py
+++ b/tests/server/single_car/single_communication_attempt/test_status.py
@@ -202,7 +202,7 @@ class Test_API_Client_Library_Func_Return_Codes_Handling(unittest.TestCase):
             self.assertIn("not among conected devices", cm.output[0])
 
     def test_incorrect_context_error_logs_error(self):
-        with self.assertLogs(LOGGER_NAME, logging.WARNING) as cm:
+        with self.assertLogs(LOGGER_NAME, logging.ERROR) as cm:
             APIClientAdapter.check_device_disconnected_code(
                 self.device,
                 EsErrorCode.CONTEXT_INCORRECT,


### PR DESCRIPTION
1. The external server logged error for any non-zero return code from device_disconnect method of an external server modules. This obscured understanding of the error origination. This is now improved. This is done in respose to https://youtrack.bringauto.com/issue/BAF-1030/Error-in-mission-module-devicedisconnected

2. The disconnect now contains additional log message for return code mqtt.MQTT_ERR_NO_CONN from the mqtt client disconnect method. For some reason, the paho mqtt client can have _ConnectionState.MQTT_CS_CONNECTED and self._sock attribute equal to None at the same time. https://youtrack.bringauto.com/issue/BAF-1035


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved device disconnection and connection status handling to reduce unexpected interruptions.
  - Enhanced error notifications during connection operations for clearer user feedback.

- **New Features**
  - Introduced standardized messaging channels for more reliable and predictable communication.

- **Refactor**
  - Streamlined logging and connection management, providing more precise diagnostic details for smoother operations.
  - Enhanced logging functionality to allow for dynamic stack level adjustments, improving logging context flexibility.
  - Adjusted log levels for better severity representation in device disconnection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->