### PR TITLE
Prepare project to be used as a package

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -32,7 +32,10 @@
 **/secrets.dev.yaml
 **/values.dev.yaml
 **/*.log
+**/*.egg-info
 htmlcov
 tests
 LICENSE
 README.md
+
+lib/fleet-protocol/protobuf/compiled/python/build

--- a/Dockerfile
+++ b/Dockerfile
@@ -92,4 +92,4 @@ RUN mkdir /home/bringauto/log/
 # "bash" and "-c" have to be used to be able to use environment variables
 # $0 and $@ are needed to pass arguments to the script
 ENTRYPOINT [ "bash", "-c", "$PYTHON_ENVIRONMENT_PYTHON3 -m external_server $0 $@" ]
-CMD [ "/home/bringauto/config/for_docker.json" ]
+CMD [ "/home/bringauto/external_server/config/for_docker.json" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,19 +66,19 @@ FROM bringauto/python-environment:latest
 # Keeps Python from buffering stdout and stderr to avoid situations where
 # the application crashes without emitting any logs due to buffering.
 ENV PYTHONUNBUFFERED=1
-# ensure PYTHONPATH is defined and append to it
-ENV PYTHONPATH=/home/bringauto/external_server:/home/bringauto/external_server/lib/fleet-protocol/protobuf/compiled/python
 
 WORKDIR /home/bringauto
 
 # Install Python dependencies while ignoring overriding system packages inside the container
 COPY requirements.txt /home/bringauto/external_server/requirements.txt
+COPY --chown=bringauto:bringauto lib /home/bringauto/external_server/lib/
+# Workdir needs to be set before installing requirements because of the local protobuf package
+WORKDIR /home/bringauto/external_server
 RUN "$PYTHON_ENVIRONMENT_PYTHON3" -m pip install --no-cache-dir -r /home/bringauto/external_server/requirements.txt
 
 # Copy project files into the docker image
 COPY external_server /home/bringauto/external_server/external_server/
 COPY config/for_docker.json /home/bringauto/config/for_docker.json
-COPY --chown=bringauto:bringauto lib/ /home/bringauto/external_server/lib/
 
 # Copy module libraries
 COPY --from=mission_module_builder /home/bringauto/modules /home/bringauto/modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,7 +78,7 @@ RUN "$PYTHON_ENVIRONMENT_PYTHON3" -m pip install --no-cache-dir -r /home/bringau
 
 # Copy project files into the docker image
 COPY external_server /home/bringauto/external_server/external_server/
-COPY config/for_docker.json /home/bringauto/config/for_docker.json
+COPY config/for_docker.json /home/bringauto/external_server/config/for_docker.json
 
 # Copy module libraries
 COPY --from=mission_module_builder /home/bringauto/modules /home/bringauto/modules

--- a/README.md
+++ b/README.md
@@ -12,22 +12,22 @@ It handles communication between a cloud instance and multiple cars registered u
 
 ## Install dependencies
 
+### Submodules
+
+First, update the [fleet protocol](https://github.com/bringauto/fleet-protocol) submodule
+
+```bash
+git submodule update --init lib/fleet-protocol
+```
+
 ### Python packages
 
-Install the required Python packages in a virtual environment by running the following:
+Install the required Python packages in a virtual environment by running the following (run pip3 install in the project root):
 
 ```bash
 python3 -m venv .venv && \
 source .venv/bin/activate && \
 pip3 install -r requirements.txt
-```
-
-### Submodules
-
-Update the [fleet protocol](https://github.com/bringauto/fleet-protocol) submodule
-
-```bash
-git submodule update --init lib/fleet-protocol
 ```
 
 ## Configure the External Server
@@ -175,4 +175,4 @@ find ./definition -name "*.proto" -exec protoc -I=./definition --python_out=./co
 popd
 ```
 
-Then add `<project-root-directory>/lib/fleet-protocol/protobuf/compiled/python`to the `PYTHONPATH` environment variable.
+Then reinstall the requirements.

--- a/README.md
+++ b/README.md
@@ -80,10 +80,10 @@ See the `config/config.json` for an example of car configuration.
 After configuration and installation of the dependencies, run External Server with this command:
 
 ```bash
-python3 external_server_main.py --config <str> [--tls] [--ca <str>] [--cert <str>] [--key <str>]
+python3 -m external_server <config> [--tls] [--ca <str>] [--cert <str>] [--key <str>]
 ```
 
-- `-c or --config <str>` = path to the config file, default = `./config/config.json`
+- `<config>` = path to the config file, default = `./config/config.json`
 - `--tls` = tls mqtt authentication
 
 Following arguments are used if argument `tls` is set:

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ After configuration and installation of the dependencies, run External Server wi
 python3 -m external_server <config> [--tls] [--ca <str>] [--cert <str>] [--key <str>]
 ```
 
-- `<config>` = path to the config file, default = `./config/config.json`
+- `<config>` = path to the config file
 - `--tls` = tls mqtt authentication
 
 Following arguments are used if argument `tls` is set:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    command: -c "./config/for_docker.json"
+    command: "./config/for_docker.json"
     restart: always
     volumes:
       - "./config:/home/bringauto/config/"

--- a/external_server/__init__.py
+++ b/external_server/__init__.py
@@ -1,6 +1,6 @@
 import os
-from .server.single_car import CarServer
-from .server.all_cars import ExternalServer
+from external_server.server.single_car import CarServer
+from external_server.server.all_cars import ExternalServer
 
 
 PATH = os.path.dirname(os.path.abspath(os.path.dirname(__file__)))

--- a/external_server/adapters/api/adapter.py
+++ b/external_server/adapters/api/adapter.py
@@ -140,10 +140,12 @@ class APIClientAdapter:
         device.priority = device_id.priority
         device.deviceType = device_id.device_type
         device.deviceRole = (
-            device_id.device_role.data.decode("utf-8") if device_id.device_role.data else ""
+            device_id.device_role.data[: device_id.device_role.size].decode("utf-8") if (
+                device_id.device_role.data and device_id.device_role.size > 0 ) else ""
         )
         device.deviceName = (
-            device_id.device_name.data.decode("utf-8") if device_id.device_name.data else ""
+            device_id.device_name.data[: device_id.device_name.size].decode("utf-8") if (
+                device_id.device_name.data and device_id.device_name.size > 0) else ""
         )
         return device
 

--- a/external_server/adapters/api/adapter.py
+++ b/external_server/adapters/api/adapter.py
@@ -1,11 +1,9 @@
-import sys
-
-sys.path.append("lib/fleet-protocol/protobuf/compiled/python")
-
-from InternalProtocol_pb2 import (  # type: ignore
+from fleet_protocol_protobuf_files.InternalProtocol_pb2 import (
     Device as _Device,
 )
-from ExternalProtocol_pb2 import Status as _Status  # type: ignore
+from fleet_protocol_protobuf_files.ExternalProtocol_pb2 import (
+    Status as _Status
+)
 from external_server.models.structures import (
     Buffer,
     DeviceIdentification,

--- a/external_server/adapters/api/module_lib.py
+++ b/external_server/adapters/api/module_lib.py
@@ -1,10 +1,7 @@
 import ctypes as ct
-import sys
 from typing import Any, Optional
 import os
 import threading
-
-sys.path.append("lib/fleet-protocol/protobuf/compiled/python")
 
 from external_server.models.structures import (
     Config,

--- a/external_server/adapters/mqtt/adapter.py
+++ b/external_server/adapters/mqtt/adapter.py
@@ -1,14 +1,11 @@
 import secrets
 import string
 from queue import Queue, Empty
-import sys
 import ssl
 from typing import Optional, Any
 import time
 import os
 import threading
-
-sys.path.append("lib/fleet-protocol/protobuf/compiled/python")
 
 import paho.mqtt.client as mqtt
 from paho.mqtt.client import (
@@ -21,7 +18,7 @@ from paho.mqtt.client import (
 from external_server.logs import CarLogger as _CarLogger
 from external_server.checkers.mqtt_session import MQTTSession
 from paho.mqtt.enums import CallbackAPIVersion
-from ExternalProtocol_pb2 import (  # type: ignore
+from fleet_protocol_protobuf_files.ExternalProtocol_pb2 import (
     Connect as _Connect,
     ExternalClient as _ExternalClientMsg,
     ExternalServer as ExternalServerMsg,

--- a/external_server/checkers/command_checker.py
+++ b/external_server/checkers/command_checker.py
@@ -1,12 +1,13 @@
 from queue import Queue
 from threading import Lock as _Lock, Timer as _Timer
-import sys
 import dataclasses
 
-sys.path.append("lib/fleet-protocol/protobuf/compiled/python")
-
-from ExternalProtocol_pb2 import CommandResponse as _CommandResponse  # type: ignore
-from InternalProtocol_pb2 import Device as _Device  # type: ignore
+from fleet_protocol_protobuf_files.ExternalProtocol_pb2 import (
+    CommandResponse as _CommandResponse
+)
+from fleet_protocol_protobuf_files.InternalProtocol_pb2 import (
+    Device as _Device
+)
 
 from external_server.checkers.checker import TimeoutChecker as _Checker
 from external_server.logs import CarLogger as _CarLogger, LOGGER_NAME

--- a/external_server/checkers/status_checker.py
+++ b/external_server/checkers/status_checker.py
@@ -1,10 +1,9 @@
 from threading import Lock as _Lock, Timer as _Timer
 from queue import PriorityQueue as _PriorityQueue, Queue as _Queue
-import sys
 
-sys.path.append("lib/fleet-protocol/protobuf/compiled/python")
-
-from ExternalProtocol_pb2 import Status as _Status  # type: ignore
+from fleet_protocol_protobuf_files.ExternalProtocol_pb2 import (
+    Status as _Status
+)
 from external_server.logs import CarLogger as _CarLogger, LOGGER_NAME
 from external_server.checkers.checker import TimeoutChecker as _Checker
 from external_server.models.structures import TimeoutType as _TimeoutType

--- a/external_server/models/devices.py
+++ b/external_server/models/devices.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 import dataclasses
 
-from InternalProtocol_pb2 import Device as _Device  # type: ignore
-from InternalProtocol_pb2 import DeviceStatus as DeviceStatus  # type: ignore
+from fleet_protocol_protobuf_files.InternalProtocol_pb2 import (
+    Device as _Device
+)
+from fleet_protocol_protobuf_files.InternalProtocol_pb2 import (
+    DeviceStatus as DeviceStatus
+)
 
 
 def device_status(device: _Device, status_data: bytes = b"") -> DeviceStatus:

--- a/external_server/models/messages.py
+++ b/external_server/models/messages.py
@@ -1,14 +1,11 @@
-import sys
 from typing import Optional
 
-sys.path.append("lib/fleet-protocol/protobuf/compiled/python")
-
-from InternalProtocol_pb2 import (  # type: ignore
+from fleet_protocol_protobuf_files.InternalProtocol_pb2 import (
     Device as _Device,
     DeviceCommand as _DeviceCommand,
     DeviceStatus as DeviceStatus,
 )
-from ExternalProtocol_pb2 import (  # type: ignore
+from fleet_protocol_protobuf_files.ExternalProtocol_pb2 import (
     Command as _Command,
     Connect as _Connect,
     CommandResponse as _CommandResponse,

--- a/external_server/models/structures.py
+++ b/external_server/models/structures.py
@@ -2,11 +2,11 @@ import ctypes as ct
 from enum import IntEnum
 import dataclasses
 
-from InternalProtocol_pb2 import (  # type: ignore
+from fleet_protocol_protobuf_files.InternalProtocol_pb2 import (
     Device as _Device,
     DeviceCommand as _DeviceCommand,
 )
-from ExternalProtocol_pb2 import (  # type: ignore
+from fleet_protocol_protobuf_files.ExternalProtocol_pb2 import (
     Command as _Command,
     ExternalServer as _ExternalServerMsg,
 )

--- a/external_server/server/all_cars.py
+++ b/external_server/server/all_cars.py
@@ -74,7 +74,7 @@ class ExternalServer:
         for t in self._car_threads.values():
             t.start()
         # The following for loop ensures, that the main thread waits for all car threads to finish
-        # This allows for the external_server_main script to run while the car threads are running
+        # This allows for the external server __main__ script to run while the car threads are running
         # This ensures the server can be stopped by KeyboardInterrupt
         if wait_for_join:
             for t in self._car_threads.values():

--- a/external_server/server/all_cars.py
+++ b/external_server/server/all_cars.py
@@ -1,10 +1,7 @@
 from __future__ import annotations
-import sys
 import threading
 
-sys.path.append("lib/fleet-protocol/protobuf/compiled/python")
-
-from ExternalProtocol_pb2 import (  # type: ignore
+from fleet_protocol_protobuf_files.ExternalProtocol_pb2 import (
     CommandResponse as _CommandResponse,
     Connect as _Connect,
     Status as _Status,

--- a/external_server/server/single_car.py
+++ b/external_server/server/single_car.py
@@ -1,20 +1,19 @@
 from __future__ import annotations
 from functools import partial
-import sys
 import enum
 from typing import Any
 import time
 
-sys.path.append("lib/fleet-protocol/protobuf/compiled/python")
-
-from ExternalProtocol_pb2 import (  # type: ignore
+from fleet_protocol_protobuf_files.ExternalProtocol_pb2 import (
     CommandResponse as _CommandResponse,
     Connect as _Connect,
     ConnectResponse as _ConnectResponse,
     ExternalClient as _ExternalClientMsg,
     Status as _Status,
 )
-from InternalProtocol_pb2 import Device as _Device  # type: ignore
+from fleet_protocol_protobuf_files.InternalProtocol_pb2 import (
+    Device as _Device
+)
 
 from external_server.logs import CarLogger as _CarLogger, LOGGER_NAME as _LOGGER_NAME
 from external_server.checkers.command_checker import (

--- a/external_server/server_module/command_waiting_thread.py
+++ b/external_server/server_module/command_waiting_thread.py
@@ -1,11 +1,10 @@
 from typing import Callable
 import threading
 from queue import Queue, Empty
-import sys
 
-sys.path.append("lib/fleet-protocol/protobuf/compiled/python")
-
-from InternalProtocol_pb2 import Device as _Device  # type: ignore
+from fleet_protocol_protobuf_files.InternalProtocol_pb2 import (
+    Device as _Device
+)
 from external_server.models.structures import GeneralErrorCode, EsErrorCode
 from external_server.adapters.api.adapter import APIClientAdapter  # type: ignore
 from external_server.models.events import EventType as _EventType, EventQueue as _EventQueue

--- a/external_server/server_module/server_module.py
+++ b/external_server/server_module/server_module.py
@@ -7,7 +7,9 @@ from external_server.server_module.command_waiting_thread import (
 )
 from external_server.config import ModuleConfig as _ModuleConfig
 from external_server.models.events import EventQueue as _EventQueue
-from InternalProtocol_pb2 import Device as _Device  # type: ignore
+from fleet_protocol_protobuf_files.InternalProtocol_pb2 import (
+    Device as _Device
+)
 from external_server.logs import CarLogger as _CarLogger, LOGGER_NAME as _LOGGER_NAME
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "external_server"
-version = "2.1.5"
+version = "2.1.6"
 
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "external_server"
-version = "2.1.6"
+version = "2.1.7"
 
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "external_server"
-version = "2.1.7"
+version = "2.2.0"
 
 
 [tool.setuptools.packages.find]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ paho-mqtt==2.0.0
 protobuf==4.25.3
 pydantic==2.6.0
 rich==13.7.1
+file:lib/fleet-protocol/protobuf/compiled/python

--- a/tests/api_access/test_api_adapter.py
+++ b/tests/api_access/test_api_adapter.py
@@ -3,10 +3,9 @@ import sys
 import os
 
 sys.path.append(".")
-sys.path.append("lib/fleet-protocol/protobuf/compiled/python")
 
 from external_server.adapters.api.adapter import APIClientAdapter
-from InternalProtocol_pb2 import Device  # type: ignore
+from fleet_protocol_protobuf_files.InternalProtocol_pb2 import Device
 from external_server.config import ModuleConfig
 from external_server.models.structures import DisconnectTypes
 from tests.utils import EXAMPLE_MODULE_SO_LIB_PATH

--- a/tests/api_access/test_command_wait_thread.py
+++ b/tests/api_access/test_command_wait_thread.py
@@ -5,12 +5,11 @@ import logging
 import threading
 
 sys.path.append(".")
-sys.path.append("lib/fleet-protocol/protobuf/compiled/python")
 
 from external_server.adapters.api.adapter import APIClientAdapter
 from external_server.server_module.command_waiting_thread import CommandWaitingThread
 from external_server.config import ModuleConfig
-from InternalProtocol_pb2 import Device  # type: ignore
+from fleet_protocol_protobuf_files.InternalProtocol_pb2 import Device
 from external_server.models.structures import EsErrorCode, GeneralErrorCode, ReturnCode
 from tests.utils import EXAMPLE_MODULE_SO_LIB_PATH
 from external_server.server_module.command_waiting_thread import logger

--- a/tests/checkers/test_command_checker.py
+++ b/tests/checkers/test_command_checker.py
@@ -3,9 +3,8 @@ import time
 import sys
 
 sys.path.append(".")
-sys.path.append("lib/fleet-protocol/protobuf/compiled/python/")
 
-from InternalProtocol_pb2 import Device  # type: ignore
+from fleet_protocol_protobuf_files.InternalProtocol_pb2 import Device
 from external_server.models.structures import HandledCommand
 from external_server.checkers.command_checker import PublishedCommandChecker
 from external_server.models.messages import cmd_response

--- a/tests/checkers/test_session_timeout_checker.py
+++ b/tests/checkers/test_session_timeout_checker.py
@@ -1,8 +1,5 @@
 import unittest
 import time
-import sys
-
-sys.path.append("lib/fleet-protocol/protobuf/compiled/python")
 
 from external_server.checkers.mqtt_session import MQTTSession
 from external_server.models.events import EventQueue

--- a/tests/checkers/test_status_order_checker.py
+++ b/tests/checkers/test_status_order_checker.py
@@ -4,9 +4,8 @@ import sys
 import logging
 
 sys.path.append(".")
-sys.path.append("lib/fleet-protocol/protobuf/compiled/python")
 
-from ExternalProtocol_pb2 import Status  # type: ignore
+from fleet_protocol_protobuf_files.ExternalProtocol_pb2 import Status
 from external_server.checkers.status_checker import StatusChecker
 from external_server.models.events import EventQueue
 

--- a/tests/models/test_device_list.py
+++ b/tests/models/test_device_list.py
@@ -1,7 +1,7 @@
 import unittest
 
 from external_server.models.devices import KnownDevices, DevicePy
-from InternalProtocol_pb2 import Device  # type: ignore
+from fleet_protocol_protobuf_files.InternalProtocol_pb2 import Device
 
 
 class Test_Known_Devices(unittest.TestCase):

--- a/tests/mqtt/test_adapter.py
+++ b/tests/mqtt/test_adapter.py
@@ -7,7 +7,6 @@ import logging
 import threading
 
 sys.path.append(".")
-sys.path.append("lib/fleet-protocol/protobuf/compiled/python")
 
 from paho.mqtt.client import MQTTMessage, Client, MQTTErrorCode
 
@@ -19,12 +18,12 @@ from external_server.adapters.mqtt.adapter import (  # type: ignore
     mqtt_error_from_code,
     _QOS,
 )
-from InternalProtocol_pb2 import (  # type: ignore
+from fleet_protocol_protobuf_files.InternalProtocol_pb2 import (
     Device,
     DeviceCommand,
     DeviceStatus,
 )
-from ExternalProtocol_pb2 import (  # type: ignore
+from fleet_protocol_protobuf_files.ExternalProtocol_pb2 import (
     CommandResponse,
     ConnectResponse,
     Connect,

--- a/tests/server/mutilple_cars/test_multiple_cars.py
+++ b/tests/server/mutilple_cars/test_multiple_cars.py
@@ -1,12 +1,9 @@
 import unittest
-import sys
 import time
 import threading
 
-sys.path.append("lib/fleet-protocol/protobuf/compiled/python")
-
-from InternalProtocol_pb2 import Device, DeviceStatus  # type: ignore
-from ExternalProtocol_pb2 import Status  # type: ignore
+from fleet_protocol_protobuf_files.InternalProtocol_pb2 import Device, DeviceStatus
+from fleet_protocol_protobuf_files.ExternalProtocol_pb2 import Status
 from external_server.server.single_car import ServerState
 from external_server.server.all_cars import ExternalServer
 from external_server.models.messages import connect_msg, status, cmd_response

--- a/tests/server/single_car/single_communication_attempt/test_command.py
+++ b/tests/server/single_car/single_communication_attempt/test_command.py
@@ -4,10 +4,12 @@ import logging
 import sys
 
 sys.path.append(".")
-sys.path.append("lib/fleet-protocol/protobuf/compiled/python")
 
-from InternalProtocol_pb2 import Device  # type: ignore
-from ExternalProtocol_pb2 import CommandResponse, ExternalServer as ExternalServerMsg  # type: ignore
+from fleet_protocol_protobuf_files.InternalProtocol_pb2 import Device
+from fleet_protocol_protobuf_files.ExternalProtocol_pb2 import (
+    CommandResponse,
+    ExternalServer as ExternalServerMsg
+)
 from external_server.server.all_cars import logger as es_logger
 from external_server.checkers.command_checker import logger as command_checker_logger
 from external_server.models.structures import HandledCommand

--- a/tests/server/single_car/single_communication_attempt/test_connect_sequence.py
+++ b/tests/server/single_car/single_communication_attempt/test_connect_sequence.py
@@ -8,8 +8,8 @@ import logging
 sys.path.append(".")
 
 from external_server.server.single_car import ServerState
-from InternalProtocol_pb2 import Device  # type: ignore
-from ExternalProtocol_pb2 import (  # type: ignore
+from fleet_protocol_protobuf_files.InternalProtocol_pb2 import Device
+from fleet_protocol_protobuf_files.ExternalProtocol_pb2 import (
     ExternalServer as ExternalServerMsg,
     Status,
     CommandResponse,

--- a/tests/server/single_car/single_communication_attempt/test_first_commands.py
+++ b/tests/server/single_car/single_communication_attempt/test_first_commands.py
@@ -1,15 +1,14 @@
 import unittest
 import sys
 from unittest.mock import patch, Mock
-import json
 
 sys.path.append(".")
 
-from InternalProtocol_pb2 import Device  # type: ignore
+from fleet_protocol_protobuf_files.InternalProtocol_pb2 import Device
 from external_server.models.structures import HandledCommand
 from external_server.models.messages import cmd_response
 from external_server.models.exceptions import ConnectSequenceFailure
-from ExternalProtocol_pb2 import CommandResponse  # type: ignore
+from fleet_protocol_protobuf_files.ExternalProtocol_pb2 import CommandResponse
 from tests.utils import get_test_car_server
 from tests.utils.mqtt_broker import MQTTBrokerTest
 

--- a/tests/server/single_car/single_communication_attempt/test_normal_communication.py
+++ b/tests/server/single_car/single_communication_attempt/test_normal_communication.py
@@ -11,8 +11,11 @@ sys.path.append(".")
 from external_server.server.single_car import CarServer, ServerState
 from external_server.server.all_cars import logger as _logger
 from external_server.models.structures import Buffer
-from InternalProtocol_pb2 import Device, DeviceStatus  # type: ignore
-from ExternalProtocol_pb2 import (  # type: ignore
+from fleet_protocol_protobuf_files.InternalProtocol_pb2 import (
+    Device,
+    DeviceStatus
+)
+from fleet_protocol_protobuf_files.ExternalProtocol_pb2 import (
     CommandResponse,
     ExternalServer as ExternalServerMsg,
     Status,

--- a/tests/server/single_car/single_communication_attempt/test_status.py
+++ b/tests/server/single_car/single_communication_attempt/test_status.py
@@ -5,10 +5,9 @@ import sys
 import time
 
 sys.path.append(".")
-sys.path.append("lib/fleet-protocol/protobuf/compiled/python")
 
-from ExternalProtocol_pb2 import Status, ExternalServer as ExternalServerMsg  # type: ignore
-from InternalProtocol_pb2 import Device, DeviceStatus  # type: ignore
+from fleet_protocol_protobuf_files.ExternalProtocol_pb2 import Status, ExternalServer as ExternalServerMsg
+from fleet_protocol_protobuf_files.InternalProtocol_pb2 import Device, DeviceStatus
 from external_server.server.all_cars import logger as _logger
 from external_server.logs import LOGGER_NAME
 from external_server.adapters.api.adapter import APIClientAdapter

--- a/tests/server/single_car/single_communication_attempt/test_unexpected_mqtt_disconnection.py
+++ b/tests/server/single_car/single_communication_attempt/test_unexpected_mqtt_disconnection.py
@@ -5,8 +5,8 @@ import time
 
 sys.path.append(".")
 
-from InternalProtocol_pb2 import Device, DeviceStatus  # type: ignore
-from ExternalProtocol_pb2 import (  # type: ignore
+from fleet_protocol_protobuf_files.InternalProtocol_pb2 import Device, DeviceStatus
+from fleet_protocol_protobuf_files.ExternalProtocol_pb2 import (
     CommandResponse,
     ExternalServer as ExternalServerMsg,
     Status,

--- a/tests/server/single_car/test_connect_sequence.py
+++ b/tests/server/single_car/test_connect_sequence.py
@@ -1,14 +1,14 @@
 import unittest
-import sys
 import time
 import threading
 
-sys.path.append("lib/fleet-protocol/protobuf/compiled/python")
-
 from pydantic import FilePath
 
-from InternalProtocol_pb2 import Device, DeviceStatus  # type: ignore
-from ExternalProtocol_pb2 import (  # type: ignore
+from fleet_protocol_protobuf_files.InternalProtocol_pb2 import (
+    Device,
+    DeviceStatus
+)
+from fleet_protocol_protobuf_files.ExternalProtocol_pb2 import (
     CommandResponse,
     ConnectResponse,
     ExternalClient as ExternalClientMsg,

--- a/tests/server/single_car/test_server_checks.py
+++ b/tests/server/single_car/test_server_checks.py
@@ -2,11 +2,10 @@ import unittest
 import sys
 
 sys.path.append(".")
-sys.path.append("lib/fleet-protocol/protobuf/compiled/python")
 
 from external_server.models.exceptions import ConnectSequenceFailure
 from external_server import CarServer as ES
-from ExternalProtocol_pb2 import Status as _Status  # type: ignore
+from fleet_protocol_protobuf_files.ExternalProtocol_pb2 import Status as _Status
 
 
 class Test_Connecting_State(unittest.TestCase):

--- a/tests/server/single_car/test_server_creation.py
+++ b/tests/server/single_car/test_server_creation.py
@@ -1,9 +1,6 @@
 import unittest
-import sys
 import concurrent.futures as futures
 import time
-
-sys.path.append("lib/fleet-protocol/protobuf/compiled/python")
 
 from pydantic import FilePath
 

--- a/tests/server/test_start_script.py
+++ b/tests/server/test_start_script.py
@@ -10,19 +10,19 @@ from external_server.__main__ import parsed_script_args
 class Test_Argparse_Init(unittest.TestCase):
 
     def test_setting_existing_config_file_path_is_allowed(self):
-        sys.argv = ["external_server_main.py", "-c", "./tests/config.json"]
-        args = parsed_script_args()
-        self.assertEqual(args.config, "./tests/config.json")
+        sys.argv = ["external_server", "./tests/config.json"]
+        args, config_path = parsed_script_args()
+        self.assertEqual(config_path, "./tests/config.json")
         self.assertIsNone(args.tls)
 
     def test_setting_nonexistent_config_file_path_raises_error(self):
-        sys.argv = ["external_server_main.py", "-c", "./nonexistent_folder/some_config.json"]
+        sys.argv = ["external_server", "./nonexistent_folder/some_config.json"]
         with self.assertRaises(FileNotFoundError):
             parsed_script_args()
 
     def test_setting_tls_flag_without_further_arguments_raises_error(self):
         with self.assertRaises(argparse.ArgumentError) as cm:
-            sys.argv = ["external_server_main.py", "-c", "./tests/config.json", "--tls"]
+            sys.argv = ["external_server", "./tests/config.json", "--tls"]
             parsed_script_args()
         self.assertIn("ca certificate", cm.exception.message)
         self.assertIn("PEM encoded client certificate", cm.exception.message)
@@ -31,8 +31,7 @@ class Test_Argparse_Init(unittest.TestCase):
     def test_setting_tls_flag_with_only_ca_certificate_missing_raises_error(self):
         with self.assertRaises(argparse.ArgumentError) as cm:
             sys.argv = [
-                "external_server_main.py",
-                "-c",
+                "external_server",
                 "./tests/config.json",
                 "--tls",
                 "--cert",
@@ -48,8 +47,7 @@ class Test_Argparse_Init(unittest.TestCase):
     def test_setting_tls_flag_with_only_PEM_certificate_missing_raises_error(self):
         with self.assertRaises(argparse.ArgumentError) as cm:
             sys.argv = [
-                "external_server_main.py",
-                "-c",
+                "external_server",
                 "./tests/config.json",
                 "--tls",
                 "--ca",
@@ -65,8 +63,7 @@ class Test_Argparse_Init(unittest.TestCase):
     def test_setting_tls_flag_with_only_private_key_missing_raises_error(self):
         with self.assertRaises(argparse.ArgumentError) as cm:
             sys.argv = [
-                "external_server_main.py",
-                "-c",
+                "external_server",
                 "./tests/config.json",
                 "--tls",
                 "--cert",
@@ -80,8 +77,7 @@ class Test_Argparse_Init(unittest.TestCase):
 
     def test_setting_tls_flag_with_ca_cert_cert_and_key_is_allowed(self):
         sys.argv = [
-            "external_server_main.py",
-            "-c",
+            "external_server",
             "./tests/config.json",
             "--tls",
             "--ca",
@@ -91,7 +87,7 @@ class Test_Argparse_Init(unittest.TestCase):
             "--key",
             "key.pem",
         ]
-        args = parsed_script_args()
+        args, _ = parsed_script_args()
         self.assertTrue(args.tls)
         self.assertEqual(args.ca, "ca.pem")
         self.assertEqual(args.cert, "cert.pem")

--- a/tests/server/test_start_script.py
+++ b/tests/server/test_start_script.py
@@ -4,7 +4,7 @@ import argparse
 
 sys.path.append(".")
 
-from external_server_main import parsed_script_args
+from external_server.__main__ import parsed_script_args
 
 
 class Test_Argparse_Init(unittest.TestCase):

--- a/tests/utils/mqtt_broker.py
+++ b/tests/utils/mqtt_broker.py
@@ -12,7 +12,7 @@ import paho.mqtt.publish as publish  # type: ignore
 import paho.mqtt.client as client  # type: ignore
 
 import external_server as _external_server
-from ExternalProtocol_pb2 import ExternalClient as Ex  # type: ignore
+from fleet_protocol_protobuf_files.ExternalProtocol_pb2 import ExternalClient as Ex
 
 
 logger = logging.getLogger("MQTT Broker")


### PR DESCRIPTION
All changes in this pull request are necessary to build this project as a standalone executable package.


bugfix:
https://youtrack.bringauto.com/issue/BAF-1069/External-server-incorrect-device-id-decoding
When decoding c char pointers, their length must be given, otherwise undefined behavior can occur.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced reliability in processing device identification data to prevent issues caused by incomplete or empty information.

- **Chores**
  - Updated the project version to 2.2.0.
  - Improved container setup with updated module versions, fixed environment paths, and streamlined startup commands.
  - Simplified server startup instructions and configuration argument usage.
  - Refined command-line argument handling for configuration file input.
  - Reorganized dependency installation steps and updated protobuf import paths for improved package management.
  - Standardized protobuf imports across the codebase by removing manual path modifications and adopting package-based imports.
  - Updated Docker and docker-compose configurations for cleaner command syntax and file placements.
  - Enhanced `.dockerignore` to exclude additional build and metadata files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->