### PR TITLE
Bump transparent-module to v1.0.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ RUN cmake -DCMAKE_BUILD_TYPE=Release -DBRINGAUTO_INSTALL=ON \
 
 FROM bringauto/cpp-build-environment:latest AS transparent_module_builder
 
-ARG TRANSPARENT_MODULE_VERSION=v1.0.2
+ARG TRANSPARENT_MODULE_VERSION=v1.0.3
 
 WORKDIR /home/bringauto/
 ADD --chown=bringauto:bringauto https://github.com/bringauto/transparent-module.git#$TRANSPARENT_MODULE_VERSION transparent-module


### PR DESCRIPTION
Fixes TC build failure caused by missing `CMCONF_INIT_SYSTEM` in transparent-module's CMLibStorage.cmake (fixed in bringauto/transparent-module#5, tagged v1.0.3).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated transparent-module dependency to v1.0.3

<!-- end of auto-generated comment: release notes by coderabbit.ai -->