### PR TITLE
fix: add CMCONF_FLEET_PROTOCOL_DIR to cmake builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN mkdir /home/bringauto/modules/cmake && \
     wget -O cmake/Dependencies.cmake https://github.com/bringauto/mission-module/raw/"$MISSION_MODULE_VERSION"/cmake/Dependencies.cmake
 
 WORKDIR /home/bringauto/modules/package_build
-RUN cmake .. -DCMAKE_BUILD_TYPE=Release -DBRINGAUTO_GET_PACKAGES_ONLY=ON
+RUN cmake .. -DCMAKE_BUILD_TYPE=Release -DBRINGAUTO_GET_PACKAGES_ONLY=ON -DCMCONF_INSTALL_AS_SYMLINK=ON
 
 # Build mission module
 WORKDIR /home/bringauto
@@ -21,7 +21,7 @@ ADD --chown=bringauto:bringauto https://github.com/bringauto/mission-module.git#
 WORKDIR /home/bringauto/mission-module/_build
 RUN cmake -DCMAKE_BUILD_TYPE=Release -DBRINGAUTO_INSTALL=ON \
     -DCMAKE_INSTALL_PREFIX=/home/bringauto/modules/mission_module/ \
-    -DFLEET_PROTOCOL_BUILD_MODULE_GATEWAY=OFF .. && \
+    -DFLEET_PROTOCOL_BUILD_MODULE_GATEWAY=OFF -DCMCONF_INSTALL_AS_SYMLINK=ON .. && \
     make install
 
 
@@ -38,7 +38,7 @@ RUN mkdir /home/bringauto/modules/cmake && \
     wget -O cmake/Dependencies.cmake https://github.com/bringauto/io-module/raw/"$IO_MODULE_VERSION"/cmake/Dependencies.cmake
 
 WORKDIR /home/bringauto/modules/package_build
-RUN cmake .. -DCMAKE_BUILD_TYPE=Release -DBRINGAUTO_GET_PACKAGES_ONLY=ON
+RUN cmake .. -DCMAKE_BUILD_TYPE=Release -DBRINGAUTO_GET_PACKAGES_ONLY=ON -DCMCONF_INSTALL_AS_SYMLINK=ON
 
 # Build io module
 WORKDIR /home/bringauto
@@ -46,7 +46,20 @@ ADD --chown=bringauto:bringauto https://github.com/bringauto/io-module.git#$IO_M
 WORKDIR /home/bringauto/io-module/_build
 RUN cmake -DCMAKE_BUILD_TYPE=Release -DBRINGAUTO_INSTALL=ON \
     -DCMAKE_INSTALL_PREFIX=/home/bringauto/modules/io_module/ \
-    -DFLEET_PROTOCOL_BUILD_MODULE_GATEWAY=OFF .. && \
+    -DFLEET_PROTOCOL_BUILD_MODULE_GATEWAY=OFF -DCMCONF_INSTALL_AS_SYMLINK=ON .. && \
+    make install
+
+FROM bringauto/cpp-build-environment:latest AS transparent_module_builder
+
+ARG TRANSPARENT_MODULE_VERSION=v1.0.3
+
+WORKDIR /home/bringauto/
+ADD --chown=bringauto:bringauto https://github.com/bringauto/transparent-module.git#$TRANSPARENT_MODULE_VERSION transparent-module
+
+WORKDIR /home/bringauto/transparent-module/_build
+RUN cmake .. -DCMAKE_BUILD_TYPE=Release -DBRINGAUTO_INSTALL=ON \
+    -DCMAKE_INSTALL_PREFIX=/home/bringauto/modules/transparent_module/ \
+    -DFLEET_PROTOCOL_BUILD_MODULE_GATEWAY=OFF -DCMCONF_INSTALL_AS_SYMLINK=ON && \
     make install
 
 FROM bringauto/python-environment:latest
@@ -71,6 +84,7 @@ COPY config/for_docker.json /home/bringauto/external_server/config/for_docker.js
 # Copy module libraries
 COPY --from=mission_module_builder /home/bringauto/modules /home/bringauto/modules
 COPY --from=io_module_builder /home/bringauto/modules /home/bringauto/modules
+COPY --from=transparent_module_builder /home/bringauto/modules /home/bringauto/modules
 
 USER 5000:5000
 RUN mkdir /home/bringauto/log/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,13 @@
 # syntax=docker/dockerfile:1
 
-FROM bringauto/cpp-build-environment:latest AS mission_module_builder
+FROM bringauto/cpp-build-environment:latest AS cpp_build_base
+
+RUN mkdir /home/bringauto/cmconf && \
+    wget -O /home/bringauto/cmconf/CMCONF_FLEET_PROTOCOLConfig.cmake \
+    https://github.com/bringauto/packager-fleet-protocol-context/raw/master/config/CMCONF_FLEET_PROTOCOLConfig.cmake
+
+
+FROM cpp_build_base AS mission_module_builder
 
 ARG MISSION_MODULE_VERSION=v1.3.0
 
@@ -13,7 +20,8 @@ RUN mkdir /home/bringauto/modules/cmake && \
     wget -O cmake/Dependencies.cmake https://github.com/bringauto/mission-module/raw/"$MISSION_MODULE_VERSION"/cmake/Dependencies.cmake
 
 WORKDIR /home/bringauto/modules/package_build
-RUN cmake .. -DCMAKE_BUILD_TYPE=Release -DBRINGAUTO_GET_PACKAGES_ONLY=ON -DCMCONF_INSTALL_AS_SYMLINK=ON
+RUN cmake .. -DCMAKE_BUILD_TYPE=Release -DBRINGAUTO_GET_PACKAGES_ONLY=ON \
+    -DCMCONF_FLEET_PROTOCOL_DIR=/home/bringauto/cmconf
 
 # Build mission module
 WORKDIR /home/bringauto
@@ -21,11 +29,12 @@ ADD --chown=bringauto:bringauto https://github.com/bringauto/mission-module.git#
 WORKDIR /home/bringauto/mission-module/_build
 RUN cmake -DCMAKE_BUILD_TYPE=Release -DBRINGAUTO_INSTALL=ON \
     -DCMAKE_INSTALL_PREFIX=/home/bringauto/modules/mission_module/ \
-    -DFLEET_PROTOCOL_BUILD_MODULE_GATEWAY=OFF -DCMCONF_INSTALL_AS_SYMLINK=ON .. && \
+    -DFLEET_PROTOCOL_BUILD_MODULE_GATEWAY=OFF \
+    -DCMCONF_FLEET_PROTOCOL_DIR=/home/bringauto/cmconf .. && \
     make install
 
 
-FROM bringauto/cpp-build-environment:latest AS io_module_builder
+FROM cpp_build_base AS io_module_builder
 
 ARG IO_MODULE_VERSION=v1.3.3
 
@@ -38,7 +47,8 @@ RUN mkdir /home/bringauto/modules/cmake && \
     wget -O cmake/Dependencies.cmake https://github.com/bringauto/io-module/raw/"$IO_MODULE_VERSION"/cmake/Dependencies.cmake
 
 WORKDIR /home/bringauto/modules/package_build
-RUN cmake .. -DCMAKE_BUILD_TYPE=Release -DBRINGAUTO_GET_PACKAGES_ONLY=ON -DCMCONF_INSTALL_AS_SYMLINK=ON
+RUN cmake .. -DCMAKE_BUILD_TYPE=Release -DBRINGAUTO_GET_PACKAGES_ONLY=ON \
+    -DCMCONF_FLEET_PROTOCOL_DIR=/home/bringauto/cmconf
 
 # Build io module
 WORKDIR /home/bringauto
@@ -46,10 +56,11 @@ ADD --chown=bringauto:bringauto https://github.com/bringauto/io-module.git#$IO_M
 WORKDIR /home/bringauto/io-module/_build
 RUN cmake -DCMAKE_BUILD_TYPE=Release -DBRINGAUTO_INSTALL=ON \
     -DCMAKE_INSTALL_PREFIX=/home/bringauto/modules/io_module/ \
-    -DFLEET_PROTOCOL_BUILD_MODULE_GATEWAY=OFF -DCMCONF_INSTALL_AS_SYMLINK=ON .. && \
+    -DFLEET_PROTOCOL_BUILD_MODULE_GATEWAY=OFF \
+    -DCMCONF_FLEET_PROTOCOL_DIR=/home/bringauto/cmconf .. && \
     make install
 
-FROM bringauto/cpp-build-environment:latest AS transparent_module_builder
+FROM cpp_build_base AS transparent_module_builder
 
 ARG TRANSPARENT_MODULE_VERSION=v1.0.3
 
@@ -59,7 +70,8 @@ ADD --chown=bringauto:bringauto https://github.com/bringauto/transparent-module.
 WORKDIR /home/bringauto/transparent-module/_build
 RUN cmake .. -DCMAKE_BUILD_TYPE=Release -DBRINGAUTO_INSTALL=ON \
     -DCMAKE_INSTALL_PREFIX=/home/bringauto/modules/transparent_module/ \
-    -DFLEET_PROTOCOL_BUILD_MODULE_GATEWAY=OFF -DCMCONF_INSTALL_AS_SYMLINK=ON && \
+    -DFLEET_PROTOCOL_BUILD_MODULE_GATEWAY=OFF \
+    -DCMCONF_FLEET_PROTOCOL_DIR=/home/bringauto/cmconf && \
     make install
 
 FROM bringauto/python-environment:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,11 @@
 
 FROM bringauto/cpp-build-environment:latest AS cpp_build_base
 
+ARG CMCONF_VERSION=master
+
 RUN mkdir /home/bringauto/cmconf && \
     wget -O /home/bringauto/cmconf/CMCONF_FLEET_PROTOCOLConfig.cmake \
-    https://github.com/bringauto/packager-fleet-protocol-context/raw/master/config/CMCONF_FLEET_PROTOCOLConfig.cmake
+    https://github.com/bringauto/packager-fleet-protocol-context/raw/"$CMCONF_VERSION"/config/CMCONF_FLEET_PROTOCOLConfig.cmake
 
 
 FROM cpp_build_base AS mission_module_builder

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,18 +49,6 @@ RUN cmake -DCMAKE_BUILD_TYPE=Release -DBRINGAUTO_INSTALL=ON \
     -DFLEET_PROTOCOL_BUILD_MODULE_GATEWAY=OFF .. && \
     make install
 
-FROM bringauto/cpp-build-environment:latest AS transparent_module_builder
-
-ARG TRANSPARENT_MODULE_VERSION=v1.0.3
-
-WORKDIR /home/bringauto/
-ADD --chown=bringauto:bringauto https://github.com/bringauto/transparent-module.git#$TRANSPARENT_MODULE_VERSION transparent-module
-
-WORKDIR /home/bringauto/transparent-module/_build
-RUN cmake .. -DCMAKE_BUILD_TYPE=Release -DBRINGAUTO_INSTALL=ON -DCMAKE_INSTALL_PREFIX=/home/bringauto/modules/transparent_module/ \
-    -DFLEET_PROTOCOL_BUILD_MODULE_GATEWAY=OFF .. && \
-    make install
-
 FROM bringauto/python-environment:latest
 
 # Keeps Python from buffering stdout and stderr to avoid situations where
@@ -83,7 +71,6 @@ COPY config/for_docker.json /home/bringauto/external_server/config/for_docker.js
 # Copy module libraries
 COPY --from=mission_module_builder /home/bringauto/modules /home/bringauto/modules
 COPY --from=io_module_builder /home/bringauto/modules /home/bringauto/modules
-COPY --from=transparent_module_builder /home/bringauto/modules /home/bringauto/modules
 
 USER 5000:5000
 RUN mkdir /home/bringauto/log/


### PR DESCRIPTION
Fixes Docker build failure caused by CMCONF v1.2.x requiring explicit config path via `-DCMCONF_FLEET_PROTOCOL_DIR`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Optimized the Docker build by adding a shared C++ build stage to centralize common CMake configuration for all module builders.
  * Updated mission, IO, and transparent module build stages to inherit from the new shared stage for consistent configuration.
  * Reduced build duplication and improved maintainability of build configuration across modules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->