### PR TITLE
Update `MISSION_MODULE_VERSION` to v1.3.1 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN mkdir /home/bringauto/cmconf && \
 
 FROM cpp_build_base AS mission_module_builder
 
-ARG MISSION_MODULE_VERSION=v1.3.0
+ARG MISSION_MODULE_VERSION=v1.3.1
 
 WORKDIR /home/bringauto/modules
 ARG CMLIB_REQUIRED_ENV_TMP_PATH=/home/bringauto/modules/cmlib_cache


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated mission module version from v1.3.0 to v1.3.1 in the build configuration, resulting in changes to deployed artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->