### PR TITLE
Resolve BAF-1393

### DIFF
--- a/external_server/adapters/mqtt/adapter.py
+++ b/external_server/adapters/mqtt/adapter.py
@@ -161,6 +161,11 @@ class MQTTClientAdapter:
         code = self._start_communication()
         return self._handle_response_code_of_setting_up_conn_to_broker(code)
 
+    def clear_received_messages(self) -> None:
+        """Discard all messages currently buffered in the received-messages queue."""
+        with self._received_msgs.mutex:
+            self._received_msgs.queue.clear()
+
     def disconnect(self) -> None:
         """Disconnect from the MQTT broker. No action is taken if the MQTT client is already disconnected."""
         code = self._mqtt_client.disconnect()

--- a/external_server/server/single_car.py
+++ b/external_server/server/single_car.py
@@ -480,6 +480,7 @@ class CarServer:
                     return response.commandResponse
             else:
                 if response.HasField("connect"):
+                    self._mqtt.received_messages.put(response)
                     raise ConnectSequenceFailure(
                         "Received connect message while waiting for command response. "
                         "Restarting init sequence."
@@ -654,7 +655,11 @@ class CarServer:
         message = self._car_message_from_mqtt()
         if message.HasField("connect"):
             # This message is not expected outside of a init sequence
-            self._handle_unexpected_connect_msg(message.connect)
+            try:
+                self._handle_unexpected_connect_msg(message.connect)
+            except CommunicationException:
+                self._mqtt.received_messages.put(message)
+                raise
         elif message.HasField("status"):
             if self._is_valid_session_id(message.status.sessionId, "status"):
                 self._reset_session_checker()

--- a/external_server/server/single_car.py
+++ b/external_server/server/single_car.py
@@ -479,11 +479,13 @@ class CarServer:
                     logger.info("Received a command response.", self._car_name)
                     return response.commandResponse
             else:
-                # ignore other messages
-                if response.HasField("status"):
+                if response.HasField("connect"):
+                    raise ConnectSequenceFailure(
+                        "Received connect message while waiting for command response. "
+                        "Restarting init sequence."
+                    )
+                elif response.HasField("status"):
                     msg_type = "status"
-                elif response.HasField("connect"):
-                    msg_type = "connect message"
                 else:
                     msg_type = "other"
                 logger.info(
@@ -498,10 +500,15 @@ class CarServer:
         # matching and not matching session ID are handled differently from the rest of the 'handle_*' methods
         if connect_msg.sessionId == self._mqtt.session.id:
             self._publish_connect_response(_ConnectResponse.ALREADY_LOGGED)
-            msg = "Received connect message with ID of already existing session. Ignoring."
+            logger.info(
+                "Received connect message with ID of already existing session. Ignoring.",
+                self._car_name,
+            )
         else:
-            msg = "Received connect message with session ID not matching current one. Ignoring."
-        logger.info(msg, self._car_name)
+            raise CommunicationException(
+                "Received connect message with session ID not matching current one. "
+                "Restarting to handle new gateway connection."
+            )
 
     def _handle_status(self, received_status: _Status) -> None:
         """Handle the status received during normal communication, i.e., after init sequence.

--- a/external_server/server/single_car.py
+++ b/external_server/server/single_car.py
@@ -299,6 +299,7 @@ class CarServer:
         """
         logger.info("Clearing the context.", self._car_name)
         self._mqtt.disconnect()
+        self._mqtt.clear_received_messages()
         self._mqtt.session.stop()
         self._command_checker.reset()
         self._status_checker.reset()
@@ -480,7 +481,6 @@ class CarServer:
                     return response.commandResponse
             else:
                 if response.HasField("connect"):
-                    self._mqtt.received_messages.put(response)
                     raise ConnectSequenceFailure(
                         "Received connect message while waiting for command response. "
                         "Restarting init sequence."
@@ -655,11 +655,7 @@ class CarServer:
         message = self._car_message_from_mqtt()
         if message.HasField("connect"):
             # This message is not expected outside of a init sequence
-            try:
-                self._handle_unexpected_connect_msg(message.connect)
-            except CommunicationException:
-                self._mqtt.received_messages.put(message)
-                raise
+            self._handle_unexpected_connect_msg(message.connect)
         elif message.HasField("status"):
             if self._is_valid_session_id(message.status.sessionId, "status"):
                 self._reset_session_checker()


### PR DESCRIPTION
YT: https://youtrack.bringauto.com/issue/BAF-1393/External-server-gets-stuck-in-deadlock-when-portal-module-fails-to-send-status

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clear buffered incoming messages when disconnecting to avoid processing stale data.
  * Treat unexpected connection messages during command-waiting as hard failures that trigger restart/recovery instead of being skipped.
  * Improve detection and handling of session mismatches with clearer logging and explicit error escalation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->