### PR TITLE
BAF-1404: Active reconnect on external server disconnect - MQTT

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -10,10 +10,13 @@
         "path": "./log/"
     }
   },
+  "external_communication": {
+    "protocol": "MQTT",
+    "server_address": "mosquitto",
+    "server_port": 1883,
+    "timeout_ms": 30000
+  },
   "company_name": "bringauto",
-  "mqtt_address": "mosquitto",
-  "mqtt_port": 1883,
-  "mqtt_timeout": 30,
   "timeout": 30,
   "send_invalid_command": false,
   "sleep_duration_after_connection_refused": 0.5,

--- a/external_server/adapters/mqtt/adapter.py
+++ b/external_server/adapters/mqtt/adapter.py
@@ -80,6 +80,7 @@ class MQTTClientAdapter:
     """
 
     _EXTERNAL_SERVER_SUFFIX = "external_server"
+    _EXTERNAL_SERVER_DISCONNECT_SUFFIX = "external_server_disconnect"
     _MODULE_GATEWAY_SUFFIX = "module_gateway"
 
     def __init__(
@@ -93,6 +94,7 @@ class MQTTClientAdapter:
         mqtt_timeout: float = 0.5,
     ) -> None:
         self._publish_topic = self.get_publish_topic(company, car)
+        self._disconnect_notification_topic = self.get_disconnect_notification_topic(company, car)
         self._subscribe_topic = self.get_subscribe_topic(company, car)
         self._received_msgs: Queue[_ExternalClientMsg] = Queue()
         self._mqtt_client = create_mqtt_client(car)
@@ -431,3 +433,18 @@ class MQTTClientAdapter:
     def get_publish_topic(company: str, car: str) -> str:
         """Return the topic the MQTT client is publishing to."""
         return f"{company}/{car}/{MQTTClientAdapter._EXTERNAL_SERVER_SUFFIX}"
+
+    @staticmethod
+    def get_disconnect_notification_topic(company: str, car: str) -> str:
+        """Return the topic used to notify the gateway that this server is disconnecting."""
+        return f"{company}/{car}/{MQTTClientAdapter._EXTERNAL_SERVER_DISCONNECT_SUFFIX}"
+
+    def publish_disconnect_notification(self) -> None:
+        """Publish an empty disconnect notification to signal the gateway to reconnect immediately."""
+        if not self._mqtt_client.is_connected():
+            return
+        code = self._mqtt_client.publish(self._disconnect_notification_topic, payload=b"", qos=_QOS).rc
+        if code != mqtt.MQTT_ERR_SUCCESS:
+            _logger.warning(
+                f"Failed to publish disconnect notification. {mqtt_error_from_code(code)}.", self._car
+            )

--- a/external_server/adapters/mqtt/adapter.py
+++ b/external_server/adapters/mqtt/adapter.py
@@ -443,8 +443,12 @@ class MQTTClientAdapter:
         """Publish an empty disconnect notification to signal the gateway to reconnect immediately."""
         if not self._mqtt_client.is_connected():
             return
-        code = self._mqtt_client.publish(self._disconnect_notification_topic, payload=b"", qos=_QOS).rc
-        if code != mqtt.MQTT_ERR_SUCCESS:
+        msg_info = self._mqtt_client.publish(self._disconnect_notification_topic, payload=b"", qos=_QOS)
+        if msg_info.rc != mqtt.MQTT_ERR_SUCCESS:
             _logger.warning(
-                f"Failed to publish disconnect notification. {mqtt_error_from_code(code)}.", self._car
+                f"Failed to publish disconnect notification. {mqtt_error_from_code(msg_info.rc)}.", self._car
             )
+            return
+        msg_info.wait_for_publish(timeout=2.0)
+        if not msg_info.is_published():
+            _logger.warning("Disconnect notification was not acknowledged before disconnecting.", self._car)

--- a/external_server/config.py
+++ b/external_server/config.py
@@ -42,7 +42,7 @@ ModuleID = Annotated[str, StringConstraints(pattern=_MODULE_ID_PATTERN)]
 
 
 class ExternalCommunicationConfig(BaseModel):
-    protocol: Literal["MQTT", "QUIC"]
+    protocol: Literal["MQTT"]
     server_port: int = Field(ge=0, le=65535)
     server_address: str
     ca_certs_file: str = ""

--- a/external_server/config.py
+++ b/external_server/config.py
@@ -9,6 +9,7 @@ from pydantic import (
     model_validator,
     StringConstraints,
     ValidationError,
+    computed_field,
 )
 
 
@@ -38,6 +39,16 @@ CompanyName = Annotated[str, StringConstraints(pattern=_COMPANY_NAME_PATTERN)]
 CarName = Annotated[str, StringConstraints(pattern=_CAR_NAME_PATTERN)]
 MQTTAdress = Annotated[str, StringConstraints(pattern=_MQTT_ADDRESS_PATTERN)]
 ModuleID = Annotated[str, StringConstraints(pattern=_MODULE_ID_PATTERN)]
+
+
+class ExternalCommunicationConfig(BaseModel):
+    protocol: Literal["MQTT", "QUIC"]
+    server_port: int = Field(ge=0, le=65535)
+    server_address: str
+    ca_certs_file: str = ""
+    cert_file: str = ""
+    key_file: str = ""
+    timeout_ms: int = Field(ge=0)
 
 
 class CarConfig(BaseModel):
@@ -79,15 +90,28 @@ class CarConfig(BaseModel):
 
 class ServerConfig(BaseModel):
     company_name: CompanyName
-    mqtt_address: MQTTAdress
-    mqtt_port: int = Field(ge=0, le=65535)
-    mqtt_timeout: float = Field(ge=0)
+    external_communication: ExternalCommunicationConfig
     timeout: float = Field(ge=0)
     send_invalid_command: bool
     sleep_duration_after_connection_refused: float = Field(ge=0)
     common_modules: dict[ModuleID, ModuleConfig]
     cars: dict[str, CarModulesConfig]
     logging: LoggingConfig
+
+    @computed_field
+    @property
+    def mqtt_address(self) -> str:
+        return self.external_communication.server_address
+
+    @computed_field
+    @property
+    def mqtt_port(self) -> int:
+        return self.external_communication.server_port
+
+    @computed_field
+    @property
+    def mqtt_timeout(self) -> float:
+        return self.external_communication.timeout_ms / 1000.0
 
     @model_validator(mode="before")
     @classmethod

--- a/external_server/server/single_car.py
+++ b/external_server/server/single_car.py
@@ -298,6 +298,7 @@ class CarServer:
         all timers and threads, clear the known devices and all queues.
         """
         logger.info("Clearing the context.", self._car_name)
+        self._mqtt.publish_disconnect_notification()
         self._mqtt.disconnect()
         self._mqtt.clear_received_messages()
         self._mqtt.session.stop()

--- a/tests/config.json
+++ b/tests/config.json
@@ -10,10 +10,13 @@
         "path": "./log/"
     }
   },
+  "external_communication": {
+    "protocol": "MQTT",
+    "server_address": "mosquitto",
+    "server_port": 1883,
+    "timeout_ms": 3000
+  },
   "company_name": "bringauto",
-  "mqtt_address": "mosquitto",
-  "mqtt_port": 1883,
-  "mqtt_timeout": 3,
   "timeout": 3,
   "send_invalid_command": false,
   "sleep_duration_after_connection_refused": 0.5,

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -19,24 +19,34 @@ EXAMPLE_MODULE_SO_LIB_PATH: FilePath = FilePath(
 )
 
 
-COMMON_CONFIG = {
-    "mqtt_address": "127.0.0.1",
-    "mqtt_port": 1883,
-    "mqtt_timeout": 2,
+_COMMON_NON_MQTT_CONFIG = {
     "timeout": 2,
     "send_invalid_command": False,
     "sleep_duration_after_connection_refused": 2,
-    "log_files_directory": ".",
-    "log_files_to_keep": 5,
-    "log_file_max_size_bytes": 100000,
     "logging": {
         "console": {"level": "DEBUG", "use": True},
         "file": {"level": "DEBUG", "use": True, "path": "./log"},
     },
 }
 
+COMMON_CONFIG = {
+    "mqtt_address": "127.0.0.1",
+    "mqtt_port": 1883,
+    "mqtt_timeout": 2,
+    **_COMMON_NON_MQTT_CONFIG,
+}
+
 CAR_CONFIG_WITHOUT_MODULES = {"company_name": "ba", "car_name": "car1", **COMMON_CONFIG}
-ES_CONFIG_WITHOUT_MODULES = {"company_name": "ba", **COMMON_CONFIG}
+ES_CONFIG_WITHOUT_MODULES = {
+    "company_name": "ba",
+    "external_communication": {
+        "protocol": "MQTT",
+        "server_address": "127.0.0.1",
+        "server_port": 1883,
+        "timeout_ms": 2000,
+    },
+    **_COMMON_NON_MQTT_CONFIG,
+}
 
 
 def get_test_server(
@@ -47,7 +57,7 @@ def get_test_server(
     config = _ServerConfig(common_modules={"1000": module_config}, **ES_CONFIG_WITHOUT_MODULES, cars=cars)  # type: ignore
     config.company_name = company
     if mqtt_timeout > 0:
-        config.mqtt_timeout = mqtt_timeout
+        config.external_communication.timeout_ms = int(mqtt_timeout * 1000)
     if timeout > 0:
         config.timeout = timeout
     es = ExternalServer(config=config)


### PR DESCRIPTION
Implements active MQTT disconnect notification: before dropping the connection, the external server publishes an explicit disconnect message on its topic so the gateway can react immediately instead of waiting for the status response timeout (~30s → <5s recovery).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added disconnect notification for MQTT to signal when a car/server disconnects.

* **Refactor**
  * Consolidated MQTT/external connection settings into a unified external communication config with derived legacy fields.

* **Tests / Chores**
  * Updated test configs and test utilities to use the new external communication structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->