### PR TITLE
BAF-1446: clear stale commands from queue on device reconnect

### DIFF
--- a/external_server/server/single_car.py
+++ b/external_server/server/single_car.py
@@ -385,6 +385,7 @@ class CarServer:
             code = self._modules[device.module].api.device_connected(device)
             if code == GeneralErrorCode.OK:
                 self._add_connected_devices(device)
+                self._modules[device.module].thread.clear_commands()
                 logger.info(f"Device {drepr} has been connected.", self._car_name)
                 return True
             logger.error(

--- a/external_server/server/single_car.py
+++ b/external_server/server/single_car.py
@@ -384,8 +384,10 @@ class CarServer:
         else:
             code = self._modules[device.module].api.device_connected(device)
             if code == GeneralErrorCode.OK:
+                module_had_connected_device = self._known_devices.any_connected_device(device.module)
                 self._add_connected_devices(device)
-                self._modules[device.module].thread.clear_commands()
+                if not module_had_connected_device:
+                    self._modules[device.module].thread.clear_commands()
                 logger.info(f"Device {drepr} has been connected.", self._car_name)
                 return True
             logger.error(

--- a/external_server/server_module/command_waiting_thread.py
+++ b/external_server/server_module/command_waiting_thread.py
@@ -99,6 +99,11 @@ class CommandWaitingThread:
         if self._waiting_thread.is_alive():
             self._waiting_thread.join()
 
+    def clear_commands(self) -> None:
+        """Discard all buffered commands. Call on device reconnect to avoid sending stale commands."""
+        with self._commands_lock:
+            self._commands.clear()
+
     def pop_command(self) -> tuple[bytes, _Device] | None:
         """Return available command if currently available, else returns None."""
         return self._commands.get()

--- a/external_server/server_module/command_waiting_thread.py
+++ b/external_server/server_module/command_waiting_thread.py
@@ -23,8 +23,9 @@ class _CommandQueue:
 
     def clear(self) -> None:
         """Clear the stored commands in the queue."""
-        while not self._queue.empty():
-            self._queue.get()
+        with self._queue.mutex:
+            self._queue.queue.clear()
+            self._queue.unfinished_tasks = 0
         logger.debug("Command queue of command waiting thread has been emptied.", self._car)
 
     def empty(self) -> bool:


### PR DESCRIPTION
## Summary

- Adds `clear_commands()` to `CommandWaitingThread` that discards all buffered commands under lock
- Calls `clear_commands()` in `_connect_device()` immediately after a device successfully connects, so any commands stranded in the queue during a prior disconnect cycle are dropped before the fresh command arrives

## Root cause

During rapid disconnect/reconnect (< 1s), a NO_ACTION command can become stranded in `_commands` while `_module_connected()=False`. When the module reconnects and a valid START command arrives, `_check_and_handle_available_commands` drains the entire queue — sending both the stale NO_ACTION and the new START to the MG. MG buffers both and the portal receives them alternately on every reconnect.

## Test plan

- [ ] Verify existing test suite passes
- [ ] Deploy to FHR and confirm bar2025_01 no longer receives alternating NO_ACTION/START commands after a reconnect event

Closes BAF-1446
Related: BAF-1441

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pending commands are now cleared when a device reconnects, preventing previously queued commands from being incorrectly executed after reconnection.
  * This reduces the risk of stale or duplicate command delivery and improves reliability of command handling during device connect/disconnect cycles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->