### PR TITLE
BAF-1446: clear stale commands on device reconnect

### DIFF
--- a/external_server/server/single_car.py
+++ b/external_server/server/single_car.py
@@ -384,10 +384,10 @@ class CarServer:
         else:
             code = self._modules[device.module].api.device_connected(device)
             if code == GeneralErrorCode.OK:
-                module_had_connected_device = self._known_devices.any_connected_device(device.module)
-                self._add_connected_devices(device)
-                if not module_had_connected_device:
-                    self._modules[device.module].thread.clear_commands()
+                self._modules[device.module].thread.perform_atomic_add_and_clear(
+                    pre_check=lambda: self._known_devices.any_connected_device(device.module),
+                    on_connect=lambda: self._add_connected_devices(device),
+                )
                 logger.info(f"Device {drepr} has been connected.", self._car_name)
                 return True
             logger.error(

--- a/external_server/server/single_car.py
+++ b/external_server/server/single_car.py
@@ -385,6 +385,7 @@ class CarServer:
             code = self._modules[device.module].api.device_connected(device)
             if code == GeneralErrorCode.OK:
                 self._add_connected_devices(device)
+                self._modules[device.module].thread.clear_commands()
                 logger.info(f"Device {drepr} has been connected.", self._car_name)
                 return True
             logger.error(

--- a/external_server/server/single_car.py
+++ b/external_server/server/single_car.py
@@ -384,8 +384,10 @@ class CarServer:
         else:
             code = self._modules[device.module].api.device_connected(device)
             if code == GeneralErrorCode.OK:
+                module_had_connected_device = self._known_devices.any_connected_device(device.module)
                 self._add_connected_devices(device)
-                self._modules[device.module].thread.clear_commands()
+                if not module_had_connected_device:
+                    self._modules[device.module].thread.clear_commands()
                 logger.info(f"Device {drepr} has been connected.", self._car_name)
                 return True
             logger.error(

--- a/external_server/server_module/command_waiting_thread.py
+++ b/external_server/server_module/command_waiting_thread.py
@@ -99,6 +99,11 @@ class CommandWaitingThread:
         if self._waiting_thread.is_alive():
             self._waiting_thread.join()
 
+    def clear_commands(self) -> None:
+        """Discard all buffered commands. Call on device reconnect to avoid sending stale commands."""
+        with self._commands_lock:
+            self._commands.clear()
+
     def pop_command(self) -> tuple[bytes, _Device] | None:
         """Return available command if currently available, else returns None."""
         return self._commands.get()

--- a/external_server/server_module/command_waiting_thread.py
+++ b/external_server/server_module/command_waiting_thread.py
@@ -105,6 +105,18 @@ class CommandWaitingThread:
         with self._commands_lock:
             self._commands.clear()
 
+    def perform_atomic_add_and_clear(
+        self,
+        pre_check: Callable[[], bool],
+        on_connect: Callable[[], None],
+    ) -> None:
+        """Under the enqueue lock: run pre_check, call on_connect, clear queue if pre_check returned False."""
+        with self._commands_lock:
+            already_had_device = pre_check()
+            on_connect()
+            if not already_had_device:
+                self._commands.clear()
+
     def pop_command(self) -> tuple[bytes, _Device] | None:
         """Return available command if currently available, else returns None."""
         return self._commands.get()

--- a/external_server/server_module/command_waiting_thread.py
+++ b/external_server/server_module/command_waiting_thread.py
@@ -23,8 +23,9 @@ class _CommandQueue:
 
     def clear(self) -> None:
         """Clear the stored commands in the queue."""
-        while not self._queue.empty():
-            self._queue.get()
+        with self._queue.mutex:
+            self._queue.queue.clear()
+            self._queue.unfinished_tasks = 0
         logger.debug("Command queue of command waiting thread has been emptied.", self._car)
 
     def empty(self) -> bool:


### PR DESCRIPTION
## Summary
- Only clear a module's command queue on device reconnect when no other device was already connected to that module (avoids dropping queued commands for other devices)
- Fix `_CommandQueue.clear()` race: replace blocking `get()` loop with atomic drain under `Queue.mutex`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device reconnection handling to clear pending commands queued while disconnected, preventing stale or incorrect operations from being executed when devices reconnect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->