### PR TITLE
Add teleop module support with per-module timeout and TCP_NODELAY

### DIFF
--- a/external_server/adapters/mqtt/adapter.py
+++ b/external_server/adapters/mqtt/adapter.py
@@ -1,4 +1,5 @@
 import secrets
+import socket
 import string
 from queue import Queue, Empty
 import ssl
@@ -45,6 +46,10 @@ ClientConnectionState = _ConnectionState
 _logger = _CarLogger()
 
 
+def _on_socket_open(client: _Client, userdata: Any, sock: Any) -> None:
+    sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+
+
 def create_mqtt_client(car: str) -> _Client:
     try:
         client_id = "".join(secrets.choice(string.ascii_letters) for _ in range(_ID_LENGTH))
@@ -55,6 +60,7 @@ def create_mqtt_client(car: str) -> _Client:
             reconnect_on_failure=True,
         )
         client.max_queued_messages_set(_MAX_QUEUED_MESSAGES)
+        client.on_socket_open = _on_socket_open
         return client
     except Exception as e:
         _logger.error(f"Failed to create MQTT client: {e}", car)

--- a/external_server/config.py
+++ b/external_server/config.py
@@ -155,6 +155,7 @@ class LoggingConfig(BaseModel):
 class ModuleConfig(BaseModel):
     lib_path: FilePath
     config: dict[str, str | int] = Field(exclude=True)
+    timeout_ms: int = Field(default=1000, ge=1)
 
 
 def load_config(config_path: str) -> ServerConfig:

--- a/external_server/server_module/server_module.py
+++ b/external_server/server_module/server_module.py
@@ -61,7 +61,7 @@ class ServerModule:
             logger.error(msg, car)
             raise RuntimeError(msg)
         self._thread = _CommandWaitingThread(
-            self._api_adapter, connection_check, event_queue=event_queue
+            self._api_adapter, connection_check, event_queue=event_queue, timeout_ms=config.timeout_ms
         )
 
     @property


### PR DESCRIPTION
- Add timeout_ms field to ModuleConfig (default 1000 ms) to allow per-module command-waiting timeout configuration
- Pass timeout_ms from module config to CommandWaitingThread instead of a hardcoded value
- Disable Nagle's algorithm (TCP_NODELAY) on MQTT sockets via on_socket_open callback to reduce latency for small messages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable timeout parameter for module operations (default: 1000ms).

* **Chores**
  * Enhanced MQTT connection configuration for improved connectivity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->