### PR TITLE
BAF-1670: build teleop module v1.1.0 (operator QUIC transport)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -123,7 +123,7 @@ RUN cmake .. -DCMAKE_BUILD_TYPE=Release -DBRINGAUTO_INSTALL=ON \
 # ============================================================================
 FROM cpp_build_base AS teleop_module_builder
 
-ARG TELEOP_MODULE_VERSION=v1.0.6
+ARG TELEOP_MODULE_VERSION=v1.1.0
 ARG TELEOP_MODULE_REPO_HOST=gitlab.bringauto.com
 ARG TELEOP_MODULE_REPO_PATH=bring-auto/teleoperation/control/teleop-module
 


### PR DESCRIPTION
## What
Bumps `TELEOP_MODULE_VERSION` `v1.0.6` → **`v1.1.0`** so the External Server image bakes in the teleop module's **operator QUIC transport** (BAF-1670) instead of the HTTP/Fleet-API path.

## Context
teleop-module `v1.1.0` (tag pushed; MR `bring-auto/teleoperation/control/teleop-module!9`) hosts a `QuicOperatorServer` inside the ES `.so`, started from `quic_*` config keys. The existing `teleop_module_builder` stage + the BuildKit gitlab-token secret are unchanged — only the pinned version moves.

## Build note to confirm on first TC build
The QUIC `.so` adds a runtime dep on `libmsquic.so.2` (+ protobuf, statically linked). These should ride into the install dir via `BA_PACKAGE_DEPS_IMPORTED` + `$ORIGIN` rpath like the other modules' deps — **verify `libmsquic.so.2` is present in `/home/bringauto/modules/teleop_module/` in the built image** (else the module fails to `dlopen` at runtime).

## After merge
Tag the repo `v2.2.14` so TC publishes `bringauto/external-server:v2.2.14`; the dev k8s deployment will point at it (BAF-1672: NodePort UDP + mTLS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the teleop module to a newer version (v1.1.0) in the Docker build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->