### PR TITLE
fix(docker): copy version.txt from teleop-module clone into modules dir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -147,7 +147,8 @@ RUN --mount=type=secret,id=gitlab_token,required=true,uid=5000 \
 RUN mkdir -p /home/bringauto/modules/cmake && \
     cp /home/bringauto/teleop-module/CMakeLists.txt      /home/bringauto/modules/CMakeLists.txt && \
     cp /home/bringauto/teleop-module/CMLibStorage.cmake  /home/bringauto/modules/CMLibStorage.cmake && \
-    cp /home/bringauto/teleop-module/cmake/Dependencies.cmake /home/bringauto/modules/cmake/Dependencies.cmake
+    cp /home/bringauto/teleop-module/cmake/Dependencies.cmake /home/bringauto/modules/cmake/Dependencies.cmake && \
+    cp /home/bringauto/teleop-module/version.txt         /home/bringauto/modules/version.txt
 WORKDIR /home/bringauto/modules/package_build
 RUN cmake .. -DCMAKE_BUILD_TYPE=Release -DBRINGAUTO_GET_PACKAGES_ONLY=ON \
     -DCMCONF_FLEET_PROTOCOL_DIR=/home/bringauto/cmconf


### PR DESCRIPTION
## Summary

- Copies `version.txt` from the teleop-module clone into `/home/bringauto/modules/` before the CMake packages-only step
- Fixes Docker build failure caused by missing `version.txt` required by CMake during dependency pre-fetch

## Test plan

- [ ] Docker build completes successfully for `v2.2.14`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build configuration to include additional module artifacts in the build context, improving build efficiency and artifact caching for the module builder stage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->