### PR TITLE
fix(mqtt): forward-port connect-discard deadlock fix onto v2.2.14 line

### DIFF
--- a/external_server/adapters/mqtt/adapter.py
+++ b/external_server/adapters/mqtt/adapter.py
@@ -230,11 +230,28 @@ class MQTTClientAdapter:
             raise CouldNotConnectToBroker(f"Could not connect to the MQTT broker. {e}") from e
 
     def get_connect_message(self) -> _Connect | None:
-        """Get expected connect message from MQTT client.
+        """Get the expected connect message from the MQTT client.
 
-        Return None if the message is not received or is not a connect message.
+        Discard any non-connect messages (e.g. statuses buffered before a reconnect) and
+        keep reading until a connect arrives or the timeout budget elapses. A single stale
+        status must NOT abort the connect sequence: doing so deadlocks (the sequence fails,
+        clears the context, retries, and meets the same buffered status again, forever).
+
+        Return None if no connect message arrives within the timeout.
         """
-        return self._get_message_field("connect")
+        deadline = time.monotonic() + (self._timeout or 0.0)
+        while True:
+            msg = self._get_message()
+            if msg is None:
+                return None
+            if msg.HasField("connect"):
+                return msg.connect
+            _logger.info(
+                f"Discarding {self._ext_client_message_type(msg)} message while waiting for connect.",
+                self._car,
+            )
+            if time.monotonic() >= deadline:
+                return None
 
     def get_status(self) -> _Status | None:
         """Get expected status message from MQTT client.

--- a/tests/mqtt/test_connect_discards_stale_status.py
+++ b/tests/mqtt/test_connect_discards_stale_status.py
@@ -1,0 +1,55 @@
+import unittest
+
+from fleet_protocol_protobuf_files.InternalProtocol_pb2 import Device  # type: ignore
+from fleet_protocol_protobuf_files.ExternalProtocol_pb2 import Status  # type: ignore
+
+from external_server.adapters.mqtt.adapter import MQTTClientAdapter  # type: ignore
+from external_server.models.messages import connect_msg, status  # type: ignore
+from external_server.models.devices import device_status as _device_status  # type: ignore
+
+
+class Test_Get_Connect_Message_Discards_Stale_Statuses(unittest.TestCase):
+    """Regression for the GW<->ES reconnect deadlock.
+
+    A status left in the received-message queue ahead of the connect (e.g. buffered around a
+    reconnect, while the gateway was still streaming at status rate) must NOT abort the connect
+    sequence. Before the fix, get_connect_message popped exactly one message and returned None on
+    a non-connect, so the sequence failed, cleared context, retried, and met the same buffered
+    status forever -> the GUI banner stayed permanently 'STATUS UNAVAILABLE'. It must instead
+    discard non-connect messages and return the connect sitting behind them.
+    """
+
+    def setUp(self) -> None:
+        # broker_host=""/port=0 -> no real broker; we drive the received-message queue directly.
+        self.adapter = MQTTClientAdapter("company", "car", timeout=1, broker_host="", port=0)
+        self.device = Device(module=1000, deviceType=0, deviceName="Test", deviceRole="test")
+
+    def test_returns_connect_when_a_status_is_queued_ahead_of_it(self) -> None:
+        self.adapter.received_messages.put(
+            status("id", Status.CONNECTING, 0, _device_status(self.device))
+        )
+        self.adapter.received_messages.put(connect_msg("id", "company", [self.device]))
+        msg = self.adapter.get_connect_message()
+        self.assertIsNotNone(msg)  # fails before the fix (returned None on the leading status)
+        self.assertEqual(msg.sessionId, "id")
+
+    def test_discards_several_stale_statuses_before_the_connect(self) -> None:
+        for counter in range(5):
+            self.adapter.received_messages.put(
+                status("id", Status.RUNNING, counter, _device_status(self.device))
+            )
+        self.adapter.received_messages.put(connect_msg("id", "company", [self.device]))
+        msg = self.adapter.get_connect_message()
+        self.assertIsNotNone(msg)
+        self.assertEqual(msg.sessionId, "id")
+
+    def test_returns_none_within_timeout_when_no_connect_arrives(self) -> None:
+        # Only statuses, never a connect: must give up (caller retries) and not hang.
+        self.adapter.received_messages.put(
+            status("id", Status.RUNNING, 0, _device_status(self.device))
+        )
+        self.assertIsNone(self.adapter.get_connect_message())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Cherry-picks the connect-sequence discard fix (d4ca131, released as v2.2.13) onto master/v2.2.14. v2.2.13 and v2.2.14 forked from a common base: v2.2.13 had the deadlock fix, v2.2.14 had the BAF-1670 QUIC + teleop-module v1.1.0 work — neither had both. This grafts the one fix commit onto the v2.2.14 line (only adapter.py + its regression test; the superseded v1.0.7 bump is intentionally not picked). Regression test passes on the merged tree; fails on stock v2.2.14 (A/B verified).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced MQTT connection robustness: the adapter now properly handles stale buffered messages during the connection handshake, discarding them to correctly process the actual connection message. Includes timeout protection to prevent indefinite waiting.

* **Tests**
  * Added regression tests for MQTT connection handling with stale messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->